### PR TITLE
Fix #7 create table if not exists by default

### DIFF
--- a/lib/model-initializer.ts
+++ b/lib/model-initializer.ts
@@ -31,7 +31,7 @@ export class ModelInitializer {
     ).createTable(
       initializationOptions.model.fields,
       initializationOptions.model.defaults,
-      true,
+      { withTimestamps: true, ifNotExists: true },
     ).toDescription();
 
     return initializationOptions.database.query(createQuery);

--- a/lib/query-builder.ts
+++ b/lib/query-builder.ts
@@ -114,9 +114,16 @@ export class QueryBuilder {
   createTable(
     fields: ModelFields,
     fieldsDefaults: ModelDefaults,
-    withTimestamps: boolean,
+    {
+      withTimestamps,
+      ifNotExists,
+    }: {
+      withTimestamps: boolean;
+      ifNotExists: boolean;
+    },
   ) {
     this._query.type = "create";
+    this._query.ifExists = ifNotExists ? false : true;
     this._query.fields = fields;
     this._query.fieldsDefaults = fieldsDefaults;
     this._query.timestamps = withTimestamps;


### PR DESCRIPTION
Now does an `if not exists` check by default whenever a table is created.

Related to #7.