### PR TITLE
Save SQLite database file on query

### DIFF
--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -33,6 +33,14 @@ export class SQLite3Connector implements Connector {
     const query = this._translator.translateToQuery(queryDescription);
     const response = this._client!.query(query, []);
 
+    if (
+      !["select", "count", "min", "max", "avg", "sum"].includes(
+        queryDescription.type!,
+      )
+    ) {
+      await saveSQLiteFile(this._client!);
+    }
+
     if (query.toLowerCase().startsWith("select")) {
       const results = [];
       let columns;


### PR DESCRIPTION
Related to #11.

SQLite database was not saved until calling `database.close()`, which would force one to call `close` after each altering query.

The database file is now saved upon any altering query (i.e. non-select queries).