### PR TITLE
Fix SQLite3 connector not running multiple subqueries in a single query

### DIFF
--- a/lib/helpers/fields.ts
+++ b/lib/helpers/fields.ts
@@ -31,11 +31,11 @@ export function addFieldToSchema(
     }
 
     if (fieldOptions.type.primaryKey) {
-      instruction = instruction.primary();
+      instruction = instruction.primary(fieldOptions.name);
     }
 
     if (fieldOptions.type.unique) {
-      instruction = instruction.unique();
+      instruction = instruction.unique(fieldOptions.name);
     }
 
     if (!fieldOptions.type.allowNull) {


### PR DESCRIPTION
This PR will also add `fieldOptions.name` aka the column name to the `primary` and `unique` method calls in `fields.ts`, with the latter fixing #18 by generating the appropriate `ALTER` queries. Despite these queries being added in, the SQLite 3 connector was unable to run them because the [SQLite library's `query` method](https://dyedgreen.github.io/deno-sqlite/#/api?id=dbquery) only runs one query at a time. I address this by splitting the query string up (by ';' token) and running each subquery one at a time, with only the last result being returned as only one result is expected from this method.

Additional Notes
- I append ';' to each query as `db.close()` will fail if a query is unfinished, which is possible if `addFieldToSchema` adds multiple query statements