### PR TITLE
Fix timestamps being true by default

### DIFF
--- a/lib/model-initializer.ts
+++ b/lib/model-initializer.ts
@@ -35,7 +35,10 @@ export class ModelInitializer {
     ).createTable(
       initializationOptions.model.fields,
       initializationOptions.model.defaults,
-      { withTimestamps: true, ifNotExists: true },
+      {
+        withTimestamps: initializationOptions.model.timestamps,
+        ifNotExists: true,
+      },
     ).toDescription();
 
     return initializationOptions.database.query(createQuery);

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -31,7 +31,7 @@ export class Model {
   static table = "";
 
   /** Should this model have `created_at` and `updated_at` fields by default. */
-  static timestamps = true;
+  static timestamps = false;
 
   /** Model fields. */
   static fields: ModelFields = {};


### PR DESCRIPTION
Fixing an issue with `Model.timestamps`.

Previously, if not specified, `Model.timestamps` would be set to `true` by default.
Even when set to `false`, it would still add timestamps fields when creating the table.

This was fixed and is now working as intended.