### PR TITLE
Add null to field values

### DIFF
--- a/lib/query-builder.ts
+++ b/lib/query-builder.ts
@@ -3,7 +3,7 @@ import { FieldTypeString } from "./data-types.ts";
 import { ModelFields, ModelDefaults, ModelSchema, Model } from "./model.ts";
 import { Relationship } from "./relationships.ts";
 
-export type FieldValue = number | string | boolean | Date;
+export type FieldValue = number | string | boolean | Date | null;
 export type Values = { [key: string]: FieldValue };
 export type FieldType = FieldTypeString | {
   type?: FieldTypeString;


### PR DESCRIPTION
Related to #34.

We couldn't use `null` values even when `allowNull` was set to true:

```typescript
class User extends Model {
  static table = "users";
  static timestamps = true;
  static fields = {
    name: {
      type: DataTypes.STRING,
      allowNull: true,
    },
  };
}

// This would previously fail
await User.create({ name: null });
```

This PR fixes it by adding `null` to possible `FieldValue`s.