### PR TITLE
Fix stacking order by statements

### DIFF
--- a/lib/model.ts
+++ b/lib/model.ts
@@ -8,6 +8,7 @@ import {
   Operator,
   QueryDescription,
   FieldType,
+  OrderByClauses,
 } from "./query-builder.ts";
 import { Database, SyncOptions } from "./database.ts";
 import { PivotModelSchema } from "./model-pivot.ts";
@@ -205,13 +206,24 @@ export class Model {
    *     await Flight.orderBy("departure").all();
    *     
    *     await Flight.orderBy("departure", "desc").all();
+   * 
+   *     await Flight.orderBy({ departure: "desc", destination: "asc" }).all();
    */
   static orderBy<T extends ModelSchema>(
     this: T,
-    field: string,
+    fieldOrFields: string | OrderByClauses,
     orderDirection: OrderDirection = "asc",
   ) {
-    this._currentQuery.orderBy(field, orderDirection);
+    if (typeof fieldOrFields === "string") {
+      this._currentQuery.orderBy(fieldOrFields, orderDirection);
+    } else {
+      for (
+        const [field, orderDirectionField] of Object.entries(fieldOrFields)
+      ) {
+        this._currentQuery.orderBy(field, orderDirectionField);
+      }
+    }
+
     return this;
   }
 

--- a/lib/query-builder.ts
+++ b/lib/query-builder.ts
@@ -52,16 +52,15 @@ export type WhereInClause = {
   possibleValues: FieldValue[];
 };
 
-export type OrderByClause = {
-  field: string;
-  orderDirection: OrderDirection;
+export type OrderByClauses = {
+  [field: string]: OrderDirection;
 };
 
 export type QueryDescription = {
   schema: ModelSchema;
   type?: QueryType;
   table?: string;
-  orderBy?: OrderByClause;
+  orderBy?: OrderByClauses;
   select?: (string | FieldAlias)[];
   wheres?: WhereClause[];
   whereIn?: WhereInClause;
@@ -159,10 +158,10 @@ export class QueryBuilder {
     field: string,
     orderDirection: OrderDirection,
   ) {
-    this._query.orderBy = {
-      field,
-      orderDirection,
-    };
+    if (!this._query.orderBy) {
+      this._query.orderBy = {};
+    }
+    this._query.orderBy[field] = orderDirection;
     return this;
   }
 

--- a/lib/translators/sql-translator.ts
+++ b/lib/translators/sql-translator.ts
@@ -46,8 +46,10 @@ export class SQLTranslator implements Translator {
 
     if (query.orderBy) {
       queryBuilder = queryBuilder.orderBy(
-        query.orderBy.field,
-        query.orderBy.orderDirection,
+        Object.entries(query.orderBy).map(([field, orderDirection]) => ({
+          column: field,
+          order: orderDirection,
+        })),
       );
     }
 


### PR DESCRIPTION
Related to #36.

New syntax for ordering by given fields:

```typescript
await Flight.orderBy('a').all();
await Flight.orderBy('a', 'desc').all();
await Flight.orderBy('a', 'desc').orderBy('b', 'desc').all();
await Flight.orderBy({ a: 'desc', b: 'desc' }).all();
```