### PR TITLE
Format attributes to database format by default

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -2,6 +2,8 @@ export { default as ConsoleColor } from "https://deno.land/x/color/index.ts";
 
 export { default as SQLQueryBuilder } from "https://deno.land/x/dex/mod.ts";
 
+export { camelCase, snakeCase } from "https://deno.land/x/case/mod.ts";
+
 export { Client as PostgresClient } from "https://deno.land/x/postgres/mod.ts";
 
 export {

--- a/lib/connectors/postgres-connector.ts
+++ b/lib/connectors/postgres-connector.ts
@@ -1,7 +1,7 @@
 import { PostgresClient } from "../../deps.ts";
 import { Connector, ConnectorOptions } from "./connector.ts";
 import { SQLTranslator } from "../translators/sql-translator.ts";
-import { QueryDescription } from "../query-builder.ts";
+import { QueryDescription, Values } from "../query-builder.ts";
 
 export interface PostgresOptions extends ConnectorOptions {
   database: string;
@@ -44,7 +44,9 @@ export class PostgresConnector implements Connector {
 
     const query = this._translator.translateToQuery(queryDescription);
     const response = await this._client.query(query);
-    const results = response.rowsOfObjects();
+    const results = this._translator.formatDatabaseResultsToClient(
+      response.rowsOfObjects(),
+    ) as Values[];
 
     if (queryDescription.type === "insert") {
       return results.length === 1 ? results[0] : results;

--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -30,8 +30,10 @@ export class SQLite3Connector implements Connector {
 
   async query(queryDescription: QueryDescription): Promise<any | any[]> {
     await this._makeConnection();
+
     const query = this._translator.translateToQuery(queryDescription);
     const subqueries = query.split(";");
+
     const results = subqueries.map(async (subquery, index) => {
       const response = this._client.query(subquery + ";", []);
 
@@ -93,7 +95,7 @@ export class SQLite3Connector implements Connector {
         results.push(result);
       }
 
-      return results;
+      return this._translator.formatDatabaseResultsToClient(results);
     });
 
     return results[results.length - 1];

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -306,7 +306,7 @@ export class Model {
     let fieldsToUpdate: Values = {};
 
     if (this.timestamps) {
-      fieldsToUpdate.updated_at = new Date();
+      fieldsToUpdate.updatedAt = new Date();
     }
 
     if (typeof fieldOrFields === "string") {

--- a/lib/translators/translator.ts
+++ b/lib/translators/translator.ts
@@ -1,7 +1,26 @@
-import { QueryDescription, Query } from "../query-builder.ts";
+import {
+  QueryDescription,
+  Query,
+  FieldAlias,
+  Values,
+} from "../query-builder.ts";
 
 /** Translator interface for translating `QueryDescription` objects to regular queries. */
 export interface Translator {
   /** Translate a query description into a regular query. */
   translateToQuery(query: QueryDescription): Query;
+
+  /** Format a field to the database format, e.g. `userName` to `user_name`. */
+  formatFieldNameToDatabase(
+    fieldName: string | FieldAlias,
+  ): string | FieldAlias;
+
+  /** Format a field from the database format to a client format, e.g. `user_name` to `userName`. */
+  formatFieldNameToClient(fieldName: string): string;
+
+  /** Format client values to database format. */
+  formatClientValuesToDatabase(values: Values | Values[]): Values[];
+
+  /** Format database results to client format. */
+  formatDatabaseResultsToClient(results: Values | Values[]): Values | Values[];
 }


### PR DESCRIPTION
Related to #41.

Attributes will now be formatted by default to database naming standards.

For example:
```javascript
class User extends Model {
  static table = 'users';
  static fields = {
    userName: DataTypes.string(25),
    emailAddress: DataTypes.STRING,
  };
}

// Will create `user_name` and `email_address`  fields in the `users` table
// But still can be queried using pascal case

const user = await User.find(1);
console.log(user.userName);
console.log(user.emailAddress);
```

This allows us to keep things clean on the client side but also on the database side.