### PR TITLE
Add offset method to model

### DIFF
--- a/lib/connectors/mongodb-connector.ts
+++ b/lib/connectors/mongodb-connector.ts
@@ -204,6 +204,10 @@ export class MongoDBConnector implements Connector {
           selectFields.push({ $limit: queryDescription.limit });
         }
 
+        if (queryDescription.offset) {
+          selectFields.push({ $skip: queryDescription.offset });
+        }
+
         results = await collection.aggregate(selectFields);
         break;
 

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -236,11 +236,19 @@ export class Model {
     return this;
   }
 
-  /** Limit the number of results returned from the query.
+  /** Similar to `limit`, limit the number of results returned from the query.
    * 
    *     await Flight.take(10).get();
    */
   static take<T extends ModelSchema>(this: T, limit: number) {
+    return this.limit(limit);
+  }
+
+  /** Limit the number of results returned from the query.
+   * 
+   *     await Flight.limit(10).get();
+   */
+  static limit<T extends ModelSchema>(this: T, limit: number) {
     this._currentQuery.limit(limit);
     return this;
   }
@@ -253,6 +261,27 @@ export class Model {
     this.take(1);
     const results = await this.get();
     return results[0];
+  }
+
+  /** Skip n values in the results.
+   * 
+   *     await Flight.offset(10).get();
+   *     
+   *     await Flight.offset(10).limit(2).get();
+   */
+  static offset<T extends ModelSchema>(this: T, offset: number) {
+    this._currentQuery.offset(offset);
+    return this;
+  }
+
+  /** Similar to `offset`, skip n values in the results.
+   * 
+   *     await Flight.skip(10).get();
+   *     
+   *     await Flight.skip(10).take(2).get();
+   */
+  static skip<T extends ModelSchema>(this: T, offset: number) {
+    return this.offset(offset);
   }
 
   /** Add a `where` clause to your query.

--- a/lib/query-builder.ts
+++ b/lib/query-builder.ts
@@ -68,6 +68,7 @@ export type QueryDescription = {
   joins?: JoinClause[];
   aggregatorField?: string;
   limit?: number;
+  offset?: number;
   ifExists?: boolean;
   fields?: ModelFields;
   fieldsDefaults?: ModelDefaults;
@@ -174,6 +175,11 @@ export class QueryBuilder {
 
   limit(limit: number) {
     this._query.limit = limit;
+    return this;
+  }
+
+  offset(offset: number) {
+    this._query.offset = offset;
     return this;
   }
 

--- a/lib/translators/sql-translator.ts
+++ b/lib/translators/sql-translator.ts
@@ -70,6 +70,10 @@ export class SQLTranslator implements Translator {
       queryBuilder = queryBuilder.limit(query.limit);
     }
 
+    if (query.offset) {
+      queryBuilder = queryBuilder.offset(query.offset);
+    }
+
     if (query.wheres) {
       query.wheres.forEach((where) => {
         queryBuilder = queryBuilder.where(


### PR DESCRIPTION
Related to #49.

Adds `offset` and sugar-version `skip` methods to `Model`:
```javascript
await Flight.skip(10).get();

await Flight.offset(10).get();

await Flight.skip(10).take(5)get();

await Flight.skip(10).limit(5)get();
```