### PR TITLE
Add field renaming

### DIFF
--- a/lib/connectors/postgres-connector.ts
+++ b/lib/connectors/postgres-connector.ts
@@ -44,9 +44,7 @@ export class PostgresConnector implements Connector {
 
     const query = this._translator.translateToQuery(queryDescription);
     const response = await this._client.query(query);
-    const results = this._translator.formatDatabaseResultsToClient(
-      response.rowsOfObjects(),
-    ) as Values[];
+    const results = response.rowsOfObjects() as Values[];
 
     if (queryDescription.type === "insert") {
       return results.length === 1 ? results[0] : results;

--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -95,7 +95,7 @@ export class SQLite3Connector implements Connector {
         results.push(result);
       }
 
-      return this._translator.formatDatabaseResultsToClient(results);
+      return results;
     });
 
     return results[results.length - 1];

--- a/lib/helpers/results.ts
+++ b/lib/helpers/results.ts
@@ -9,7 +9,8 @@ export function formatResultToModelInstance(
   const instance = new Schema();
 
   for (const field in fields) {
-    (instance as any)[field] = fields[field];
+    (instance as any)[Schema.formatFieldToClient(field) as string] =
+      fields[field];
   }
 
   return instance;

--- a/lib/query-builder.ts
+++ b/lib/query-builder.ts
@@ -7,6 +7,7 @@ export type FieldValue = number | string | boolean | Date | null;
 export type Values = { [key: string]: FieldValue };
 export type FieldType = FieldTypeString | {
   type?: FieldTypeString;
+  as?: string;
   primaryKey?: boolean;
   unique?: boolean;
   autoIncrement?: boolean;

--- a/lib/translators/translator.ts
+++ b/lib/translators/translator.ts
@@ -1,26 +1,16 @@
-import {
-  QueryDescription,
-  Query,
-  FieldAlias,
-  Values,
-} from "../query-builder.ts";
+import { QueryDescription, Query, FieldAlias } from "../query-builder.ts";
 
 /** Translator interface for translating `QueryDescription` objects to regular queries. */
-export interface Translator {
+export class Translator {
   /** Translate a query description into a regular query. */
-  translateToQuery(query: QueryDescription): Query;
+  translateToQuery(query: QueryDescription): Query {
+    return "";
+  }
 
   /** Format a field to the database format, e.g. `userName` to `user_name`. */
   formatFieldNameToDatabase(
     fieldName: string | FieldAlias,
-  ): string | FieldAlias;
-
-  /** Format a field from the database format to a client format, e.g. `user_name` to `userName`. */
-  formatFieldNameToClient(fieldName: string): string;
-
-  /** Format client values to database format. */
-  formatClientValuesToDatabase(values: Values | Values[]): Values[];
-
-  /** Format database results to client format. */
-  formatDatabaseResultsToClient(results: Values | Values[]): Values | Values[];
+  ): string | FieldAlias {
+    return fieldName;
+  }
 }


### PR DESCRIPTION
Related to #51 and #43.

Adds the `as` field decorator to rename fields:
```typescript
static fields = {
  flightID: {
    type: DataTypes.INTEGER,
    as: 'flight_weird_id',
  },
};

await Flight.insert({ flightID: 1 });
// Should map `flightID` to `flight_weird_id` when added to the database

const flight = await Flight.find(1);
console.log(flight.flightID);
// Should map `flight_weird_id` to `flightID`
```