### PR TITLE
Lazy-load mongodb library

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -12,9 +12,3 @@ export {
 } from "https://deno.land/x/mysql/mod.ts";
 
 export { DB as SQLiteClient } from "https://deno.land/x/sqlite@v2.0.0/mod.ts";
-
-export {
-  MongoClient as MongoDBClient,
-  ClientOptions as MongoDBClientOptions,
-  Database as MongoDBDatabase,
-} from "https://deno.land/x/mongo@v0.8.0/mod.ts";

--- a/unstable_deps.ts
+++ b/unstable_deps.ts
@@ -1,0 +1,15 @@
+/**
+ * When using unstable dependencies, users need to add `--unstable` and
+ * in some cases `--allow-plugin`. In order to make this optional and only
+ * required when importing unstable dependencies, this is for now a separate
+ * file that will only be imported when needed and therefore not always
+ * necessary for other usage that does not require plugins/unstable deps.
+ */
+
+export {
+  MongoClient as MongoDBClient,
+  ClientOptions as MongoDBClientOptions,
+  Database as MongoDBDatabase,
+  init as initMongoDBPlugin,
+  RELEASE_URL as MONGODB_PLUGIN_RELEASE_URL,
+} from "https://raw.githubusercontent.com/eveningkid/deno_mongo/master/mod.ts";


### PR DESCRIPTION
Related to #54.

Denodb is now using [a separate fork](https://github.com/eveningkid/deno_mongo) for mongodb.
As long as mongodb can't be lazy-loaded, this will remain.