### PR TITLE
Foreign key types fix

### DIFF
--- a/lib/connectors/postgres-connector.ts
+++ b/lib/connectors/postgres-connector.ts
@@ -1,7 +1,8 @@
 import { PostgresClient } from "../../deps.ts";
 import { Connector, ConnectorOptions } from "./connector.ts";
 import { SQLTranslator } from "../translators/sql-translator.ts";
-import { QueryDescription, Values } from "../query-builder.ts";
+import { QueryDescription } from "../query-builder.ts";
+import { Values } from '../data-types.ts';
 
 export interface PostgresOptions extends ConnectorOptions {
   database: string;

--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -1,6 +1,7 @@
 import { SQLiteClient } from "../../deps.ts";
 import { Connector, ConnectorOptions } from "./connector.ts";
-import { FieldValue, QueryDescription } from "../query-builder.ts";
+import { QueryDescription } from "../query-builder.ts";
+import { FieldValue } from '../data-types.ts';
 import { SQLTranslator } from "../translators/sql-translator.ts";
 
 export interface SQLite3Options extends ConnectorOptions {

--- a/lib/data-types.ts
+++ b/lib/data-types.ts
@@ -1,6 +1,6 @@
 import { ModelSchema } from './model.ts';
 
-/* Field Types */
+/** Field Types. */
 export type FieldTypeString =
   | "bigInteger"
   | "integer"
@@ -74,11 +74,10 @@ export type FieldOptions = {
   type: FieldType;
   defaultValue: FieldValue;
 };
-// Field Types
 
 export type Values = { [key: string]: FieldValue };
 
-/* Relationship Types */
+/** Relationship Types. */
 export type Relationship = {
   kind: "single" | "multiple";
   model: ModelSchema;
@@ -88,7 +87,6 @@ export type RelationshipType = {
   type: FieldTypeString;
   relationship: Relationship;
 };
-// Relationship Types
 
 /** Available fields data types. */
 export const DATA_TYPES: Fields = {

--- a/lib/data-types.ts
+++ b/lib/data-types.ts
@@ -1,3 +1,6 @@
+import { ModelSchema } from './model.ts';
+
+/* Field Types */
 export type FieldTypeString =
   | "bigInteger"
   | "integer"
@@ -49,6 +52,43 @@ export type Fields =
       values: (number | string)[],
     ) => { type: FieldTypeString; values: (number | string)[] };
   };
+
+export type FieldType = FieldTypeString | {
+  type?: FieldTypeString;
+  as?: string;
+  primaryKey?: boolean;
+  unique?: boolean;
+  autoIncrement?: boolean;
+  length?: number;
+  allowNull?: boolean;
+  precision?: number;
+  scale?: number;
+  values?: (number | string)[];
+  relationship?: Relationship;
+};
+
+export type FieldAlias = { [k: string]: string };
+export type FieldValue = number | string | boolean | Date | null;
+export type FieldOptions = {
+  name: string;
+  type: FieldType;
+  defaultValue: FieldValue;
+};
+// Field Types
+
+export type Values = { [key: string]: FieldValue };
+
+/* Relationship Types */
+export type Relationship = {
+  kind: "single" | "multiple";
+  model: ModelSchema;
+};
+
+export type RelationshipType = {
+  type: FieldTypeString;
+  relationship: Relationship;
+};
+// Relationship Types
 
 /** Available fields data types. */
 export const DATA_TYPES: Fields = {

--- a/lib/helpers/fields.ts
+++ b/lib/helpers/fields.ts
@@ -14,12 +14,12 @@ export function addFieldToSchema(
   if (typeof fieldOptions.type === "object") {
     if (fieldOptions.type.relationship) {
 
-      const relationshipPKName: string = fieldOptions.type.relationship.model
+      const relationshipPKName = fieldOptions.type.relationship.model
         .getComputedPrimaryKey();
 
       const relationshipPKType: FieldTypeString = fieldOptions.type.relationship.model
         .getComputedPrimaryType();
-        
+      
       table[relationshipPKType](fieldOptions.name);
 
       table

--- a/lib/helpers/fields.ts
+++ b/lib/helpers/fields.ts
@@ -13,7 +13,6 @@ export function addFieldToSchema(
 
   if (typeof fieldOptions.type === "object") {
     if (fieldOptions.type.relationship) {
-
       const relationshipPKName = fieldOptions.type.relationship.model
         .getComputedPrimaryKey();
 

--- a/lib/helpers/fields.ts
+++ b/lib/helpers/fields.ts
@@ -1,10 +1,4 @@
-import { FieldType, FieldValue } from "../query-builder.ts";
-
-type FieldOptions = {
-  name: string;
-  type: FieldType;
-  defaultValue: FieldValue;
-};
+import { FieldOptions, DataTypes, FieldTypeString } from "../data-types.ts";
 
 /** Add a model field to a table schema. */
 export function addFieldToSchema(
@@ -19,15 +13,21 @@ export function addFieldToSchema(
 
   if (typeof fieldOptions.type === "object") {
     if (fieldOptions.type.relationship) {
-      const relationshipPKName = fieldOptions.type.relationship.model
+      const relationshipPKField = fieldOptions.type.relationship.model
         .getComputedPrimaryKey();
 
-      table.string(fieldOptions.name);
-      table.foreign(fieldOptions.name).references(
-        fieldOptions.type.relationship.model.field(
-          relationshipPKName,
-        ),
-      ).onDelete("CASCADE");
+      const pkFieldType: FieldTypeString = fieldOptions.type.relationship.model
+        .getComputedPrimaryType();
+        
+      table[pkFieldType || DataTypes.STRING](fieldOptions.name);
+
+      table
+        .foreign(fieldOptions.name)
+        .references(
+            fieldOptions.type.relationship.model
+              .field(relationshipPKField)
+          )
+        .onDelete("CASCADE");
 
       return;
     }

--- a/lib/helpers/fields.ts
+++ b/lib/helpers/fields.ts
@@ -13,19 +13,20 @@ export function addFieldToSchema(
 
   if (typeof fieldOptions.type === "object") {
     if (fieldOptions.type.relationship) {
-      const relationshipPKField = fieldOptions.type.relationship.model
+
+      const relationshipPKName: string = fieldOptions.type.relationship.model
         .getComputedPrimaryKey();
 
-      const pkFieldType: FieldTypeString = fieldOptions.type.relationship.model
+      const relationshipPKType: FieldTypeString = fieldOptions.type.relationship.model
         .getComputedPrimaryType();
-        
-      table[pkFieldType || DataTypes.STRING](fieldOptions.name);
+
+      table[relationshipPKType](fieldOptions.name);
 
       table
         .foreign(fieldOptions.name)
         .references(
             fieldOptions.type.relationship.model
-              .field(relationshipPKField)
+              .field(relationshipPKName)
           )
         .onDelete("CASCADE");
 

--- a/lib/helpers/results.ts
+++ b/lib/helpers/results.ts
@@ -1,5 +1,5 @@
 import { ModelSchema } from "../model.ts";
-import { Values } from "../query-builder.ts";
+import { Values } from "../data-types.ts";
 
 /** Transform a plain record object to a given model schema. */
 export function formatResultToModelInstance(

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -136,9 +136,7 @@ export class Model {
 
   /** Manually find the primary key by going through the schema fields. */
   private static _findPrimaryKey(): string {
-    const field: FieldOptions = this._findPrimaryField();
-
-    return field.name;
+    return this._findPrimaryField().name;
   }
 
   /** Return the model computed primary key. */
@@ -150,13 +148,13 @@ export class Model {
     return this._primaryKey;
   }
 
-  /** Returns the FieldType of the Primary Key. Always returns a FieldTypeString */
+  /** Return the field type of the primary key. */
   static getComputedPrimaryType(): FieldTypeString {
     const field = this._findPrimaryField();
 
     return typeof field.type === "object" 
-        ? (field.type as any).type ?? DataTypes.INTEGER 
-        : field.type ?? DataTypes.INTEGER;
+        ? (field.type as any).type 
+        : field.type;
   }
 
   /** Build the current query and run it on the associated database. */

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -129,8 +129,8 @@ export class Model {
 
     return {
       name: field ? field[0] : "",
-      type: field ? field[1] : DataTypes.STRING,
-      defaultValue: "",
+      type: field ? field[1] : DataTypes.INTEGER,
+      defaultValue: 0,
     }
   }
 
@@ -144,7 +144,7 @@ export class Model {
   /** Return the model computed primary key. */
   static getComputedPrimaryKey(): string {
     if (!this._primaryKey) {
-      this._findPrimaryKey();
+      this._primaryKey = this._findPrimaryKey();
     }
 
     return this._primaryKey;
@@ -154,9 +154,9 @@ export class Model {
   static getComputedPrimaryType(): FieldTypeString {
     const field = this._findPrimaryField();
 
-    return field.type === "object" 
-        ? (field.type as any).type || DataTypes.STRING 
-        : field.type;
+    return typeof field.type === "object" 
+        ? (field.type as any).type ?? DataTypes.INTEGER 
+        : field.type ?? DataTypes.INTEGER;
   }
 
   /** Build the current query and run it on the associated database. */

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -128,7 +128,7 @@ export class Model {
     );
 
     return {
-      name: field ? field[0] : "",
+      name: field ? this.formatFieldToDatabase(field[0]) as string : "",
       type: field ? field[1] : DataTypes.INTEGER,
       defaultValue: 0,
     }

--- a/lib/query-builder.ts
+++ b/lib/query-builder.ts
@@ -1,24 +1,6 @@
 import { SQLQueryBuilder } from "../deps.ts";
-import { FieldTypeString } from "./data-types.ts";
+import { FieldValue, FieldAlias, Values } from "./data-types.ts";
 import { ModelFields, ModelDefaults, ModelSchema, Model } from "./model.ts";
-import { Relationship } from "./relationships.ts";
-
-export type FieldValue = number | string | boolean | Date | null;
-export type Values = { [key: string]: FieldValue };
-export type FieldType = FieldTypeString | {
-  type?: FieldTypeString;
-  as?: string;
-  primaryKey?: boolean;
-  unique?: boolean;
-  autoIncrement?: boolean;
-  length?: number;
-  allowNull?: boolean;
-  precision?: number;
-  scale?: number;
-  values?: (number | string)[];
-  relationship?: Relationship;
-};
-export type FieldAlias = { [k: string]: string };
 
 export type Query = string;
 export type Operator = ">" | ">=" | "<" | "<=" | "=";

--- a/lib/relationships.ts
+++ b/lib/relationships.ts
@@ -1,22 +1,12 @@
 import { ModelSchema } from "./model.ts";
-import { DataTypes, FieldTypeString } from "./data-types.ts";
+import { DataTypes, FieldTypeString, RelationshipType } from "./data-types.ts";
 import { PivotModel } from "./model-pivot.ts";
-
-export type Relationship = {
-  kind: "single" | "multiple";
-  model: ModelSchema;
-};
-
-export type RelationshipType = {
-  type: FieldTypeString;
-  relationship: Relationship;
-};
 
 export const Relationships = {
   /** Define a one-to-one or one-to-many relationship for a given model. */
-  belongsTo(model: ModelSchema): RelationshipType {
+  belongsTo(model: ModelSchema, dataType?: FieldTypeString): RelationshipType {
     return {
-      type: DataTypes.INTEGER,
+      type: dataType || DataTypes.INTEGER,
       relationship: {
         kind: "single",
         model,

--- a/lib/relationships.ts
+++ b/lib/relationships.ts
@@ -4,9 +4,9 @@ import { PivotModel } from "./model-pivot.ts";
 
 export const Relationships = {
   /** Define a one-to-one or one-to-many relationship for a given model. */
-  belongsTo(model: ModelSchema, dataType?: FieldTypeString): RelationshipType {
+  belongsTo(model: ModelSchema): RelationshipType {
     return {
-      type: dataType || DataTypes.INTEGER,
+      type: DataTypes.INTEGER,
       relationship: {
         kind: "single",
         model,

--- a/lib/translators/sql-translator.ts
+++ b/lib/translators/sql-translator.ts
@@ -1,7 +1,8 @@
 import { Translator } from "./translator.ts";
 import { DatabaseDialect } from "../database.ts";
 import { SQLQueryBuilder, snakeCase } from "../../deps.ts";
-import { Query, QueryDescription, FieldAlias } from "../query-builder.ts";
+import { Query, QueryDescription } from "../query-builder.ts";
+import { FieldAlias } from '../data-types.ts';
 import { addFieldToSchema } from "../helpers/fields.ts";
 
 export class SQLTranslator extends Translator {

--- a/lib/translators/translator.ts
+++ b/lib/translators/translator.ts
@@ -1,4 +1,5 @@
-import { QueryDescription, Query, FieldAlias } from "../query-builder.ts";
+import { QueryDescription, Query } from "../query-builder.ts";
+import { FieldAlias } from '../data-types.ts';
 
 /** Translator interface for translating `QueryDescription` objects to regular queries. */
 export class Translator {


### PR DESCRIPTION
(This is my first PR, sorry in advance if I missed or left out anything)

Currently in DenoDB relationship fields are hardcoded to be string fields when being generated (see [fields.ts](https://github.com/eveningkid/denodb/blob/master/lib/helpers/fields.ts#L25)) which caused a problem for me when I tried to set a primary key type to `uuid`.

With this PR DenoDB will now get the `FieldTypeString` of the foreign key, and set the generated field type to that, examples below:

Model 1:
```
id: {
        type: DataTypes.UUID,
        primaryKey: true
},
text: DataTypes.STRING
```

Model 2:
```
id: {
        type: DataTypes.INTEGER,
        autoIncrement: true,
        primaryKey: true
},
modelId:Relationships.belongsTo(PageModel),
```

(Before PR)
SQL Output
```
create table if not exists "model1_table" 
	(
		"id" serial primary key, 
		"text" varchar(255)
	);

create table if not exists "model2_table" 
	(
		"id" serial primary key, 
		"model_id" varchar(255) // varchar(255) instead of uuid
	);
```
(After PR)
it'll generate something like this

SQL Output
```
create table if not exists "model1_table" 
	(
		"id" serial primary key, 
		"text" varchar(255)
	);

create table if not exists "model2_table" 
	(
		"id" serial primary key, 
		"model_id" uuid // is now correctly uuid instead of varchar(255)
	);
```

I also moved almost everything dealing with Field Types to `data-types.ts` and made some of the code related to the changes I made a little cleaner and more readable in my opinion, if any changes I made are an issue I'll reverse them, or you can just use this PR as a baseline to fix the issues on your own, just looking forward to DenoDB getting improved so I can use it in my project :)