### PR TITLE
Fixed the snake case fields (table1_id), so many to many relationships work again

### DIFF
--- a/lib/translators/sql-translator.ts
+++ b/lib/translators/sql-translator.ts
@@ -1,6 +1,6 @@
 import { Translator } from "./translator.ts";
 import type { DatabaseDialect } from "../database.ts";
-import { SQLQueryBuilder, snakeCase } from "../../deps.ts";
+import { SQLQueryBuilder, camelCase } from "../../deps.ts";
 import type { Query, QueryDescription } from "../query-builder.ts";
 import type { FieldAlias } from '../data-types.ts';
 import { addFieldToSchema } from "../helpers/fields.ts";
@@ -221,10 +221,10 @@ export class SQLTranslator extends Translator {
       // Table.fieldName
       if (dotIndex !== -1) {
         return fieldName.slice(0, dotIndex + 1) +
-          snakeCase(fieldName.slice(dotIndex + 1));
+          camelCase(fieldName.slice(dotIndex + 1));
       }
 
-      return snakeCase(fieldName);
+      return camelCase(fieldName);
     } else {
       return Object.entries(fieldName).reduce((prev, [alias, fullName]) => {
         prev[alias] = this.formatFieldNameToDatabase(fullName);


### PR DESCRIPTION
This fixes #124 .
_snakeCase_ creates table1_id and table2_id names, but in https://github.com/eveningkid/denodb/blob/master/lib/relationships.ts#L36 camelCase is used (directly in the string).

Another fix would be to use`${modelA.name.toLowerCase()}_id` (and respectively `${modelB.name.toLowerCase()}_id`) instead. If you want, I can create another pull request for this.