### PR TITLE
Fix FieldValue type error

### DIFF
--- a/lib/data-types.ts
+++ b/lib/data-types.ts
@@ -70,7 +70,15 @@ export type FieldProps = {
 export type FieldType = FieldTypeString | FieldProps;
 
 export type FieldAlias = { [k: string]: string };
-export type FieldValue = number | string | boolean | Date | null;
+
+export type FieldValue =
+  | number
+  | string
+  | boolean
+  | Date
+  | (() => FieldValue)
+  | null;
+
 export type FieldOptions = {
   name: string;
   type: FieldType;


### PR DESCRIPTION
Hey! I found a type error with FieldValue

```
error: TS2322 [ERROR]: Type 'string | number | boolean | Date | (() => FieldValue) | null' is not assignable to type 'FieldValue'.
  Type '() => FieldValue' is not assignable to type 'FieldValue'.
    Type '() => FieldValue' is missing the following properties from type 'Date': toDateString, toTimeString, toLocaleDateString, toLocaleTimeString, and 37 more.
                  defaultValue: fieldDefaults[field],
                  ~~~~~~~~~~~~
    at https://deno.land/x/denodb@v1.0.15/lib/translators/sql-translator.ts:144:19

    The expected type comes from property 'defaultValue' which is declared here on type 'FieldOptions'
      defaultValue: FieldValue;
      ~~~~~~~~~~~~
        at https://deno.land/x/denodb@v1.0.15/lib/data-types.ts:77:3
```

If there is a problem, let me know!
(I already did deno fmt)