### PR TITLE
Add model events

### DIFF
--- a/lib/model.ts
+++ b/lib/model.ts
@@ -263,6 +263,18 @@ export class Model {
     return this;
   }
 
+  /** Alias for `Model.on`, add an event listener for a specific operation/hook.
+   * 
+   *     Flight.addEventListener('created', (model) => console.log('New model:', model));
+   */
+  static addEventListener<T extends ModelSchema>(
+    this: T,
+    eventType: ModelEventType,
+    callback: ModelEventListener,
+  ) {
+    return this.on(eventType, callback);
+  }
+
   static removeEventListener(
     eventType: ModelEventType,
     callback: ModelEventListener,


### PR DESCRIPTION
This closes #69.

It adds support for model events as follow:
```js
Flight
  .on("created", (model: Flight) => {
    console.log('Created:', model);
  })
  .on("updating", () => {
    console.log("Updating model");
  })
  .on("deleted", (model: Flight) => {
    console.log("Deleted:", model);
  });
```

You can also use `addEventListener` instead of `on`:
```js
Flight.addEventListener("created", (model: Flight) => {
  console.log('Created:', model);
});
```

An event can also be removed:
```js
const onCreated = (model: Flight) => {
  console.log('Created:', model);
};

Flight.addEventListener("created", onCreated);
Flight.removeEventListener("created", onCreated);
```