### PR TITLE
Fix database query results types

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -1,5 +1,10 @@
 import type { Connector } from "./connectors/connector.ts";
-import type { ModelSchema, FieldMatchingTable, ModelFields } from "./model.ts";
+import type {
+  FieldMatchingTable,
+  Model,
+  ModelFields,
+  ModelSchema,
+} from "./model.ts";
 import { QueryBuilder, QueryDescription } from "./query-builder.ts";
 import {
   PostgresConnector,
@@ -9,10 +14,10 @@ import {
   SQLite3Connector,
   SQLite3Options,
 } from "./connectors/sqlite3-connector.ts";
-import { MySQLOptions, MySQLConnector } from "./connectors/mysql-connector.ts";
+import { MySQLConnector, MySQLOptions } from "./connectors/mysql-connector.ts";
 import {
-  MongoDBOptions,
   MongoDBConnector,
+  MongoDBOptions,
 } from "./connectors/mongodb-connector.ts";
 import { formatResultToModelInstance } from "./helpers/results.ts";
 import { Translator } from "./translators/translator.ts";
@@ -151,7 +156,7 @@ export class Database {
    *
    *     await db.query("SELECT * FROM `flights`");
    */
-  async query(query: QueryDescription): Promise<any> {
+  async query(query: QueryDescription): Promise<Model | Model[]> {
     if (this._debug) {
       console.log(query);
     }


### PR DESCRIPTION
`Database.query` used to return `Promise<any>` which wasn't convenient to work with at all.

It now returns `Promise<Model | Model[]>` based on a single record or a list of them.

Every querying method from `Model` has been updated accordingly.