### PR TITLE
Fix MongoDBConnector close function

### DIFF
--- a/lib/connectors/mongodb-connector.ts
+++ b/lib/connectors/mongodb-connector.ts
@@ -289,6 +289,7 @@ export class MongoDBConnector implements Connector {
       return;
     }
 
+    this._client.close();
     this._connected = false;
   }
 }


### PR DESCRIPTION
This fixes #164 
Added missing `.close()` call to the mongo client in `lib/connectors/mongodb-connector.ts`