### PR TITLE
Update connectors.md

### DIFF
--- a/docs/v1.0.21-migration/connectors.md
+++ b/docs/v1.0.21-migration/connectors.md
@@ -70,10 +70,10 @@ const connector = new PostgresConnector({
   database: 'airlines',
 });
 
-const db = new Database({
+const db = new Database(
   connector,
   debug: true, // <-
-});
+);
 ```
 
 And what if you get the database type from an environment variable or somewhere else? You can still keep it similar to what we had before:


### PR DESCRIPTION
Arguments are wrapped around the curly braces, while docs [here](https://eveningkid.com/denodb-docs/docs/guides/connect-database) don't wrap them around as in object syntax