### PR TITLE
Added type Model to update method

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -9,7 +9,7 @@ export {
   Connection as MySQLConnection,
 } from "https://deno.land/x/mysql/mod.ts";
 
-export { Client as PostgresClient } from "https://raw.githubusercontent.com/deno-postgres/deno-postgres/master/mod.ts";
+export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.4.6/mod.ts";
 
 export { DB as SQLiteClient } from "https://deno.land/x/sqlite@v2.3.1/mod.ts";
 

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -625,7 +625,7 @@ export class Model {
         .table(this.table)
         .update(fieldsToUpdate)
         .toDescription(),
-    ) as Promise<Model[]>;
+    ) as Promise<Model | Model[]>;
   }
 
   /** Delete a record by a primary key value.


### PR DESCRIPTION
I was using the Mode.update method and discovered that although the type returned is Model[], in reality I was getting a type Model. Digging in the code I discovered that the _runQuery method can return Model | Model[], so I added same type to method update.

Example of the code that was failing for me:
```
const comment = await Comment.where('id', params.id).update(bodyParams);
if (comment.length) { // This was alway false, because the method was returning a Model and not an array
return true;
}
```