### PR TITLE
Avoid make subqueries from escape semicolons (issue #128 and #149)

### DIFF
--- a/lib/connectors/mysql-connector.ts
+++ b/lib/connectors/mysql-connector.ts
@@ -62,7 +62,7 @@ export class MySQLConnector implements Connector {
 
     const queryClient = client ?? this._client;
     const query = this._translator.translateToQuery(queryDescription);
-    const subqueries = query.split(/(?<!\\);/);
+    const subqueries = query.split(/;(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/);
     const queryMethod = query.toLowerCase().startsWith("select")
       ? "query"
       : "execute";

--- a/lib/connectors/mysql-connector.ts
+++ b/lib/connectors/mysql-connector.ts
@@ -62,7 +62,7 @@ export class MySQLConnector implements Connector {
 
     const queryClient = client ?? this._client;
     const query = this._translator.translateToQuery(queryDescription);
-    const subqueries = query.split(";");
+    const subqueries = query.split(/(?<!\\);/);
     const queryMethod = query.toLowerCase().startsWith("select")
       ? "query"
       : "execute";

--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -52,7 +52,7 @@ export class SQLite3Connector implements Connector {
     await this._makeConnection();
 
     const query = this._translator.translateToQuery(queryDescription);
-    const subqueries = query.split(/(?<!\\);/);
+    const subqueries = query.split(/;(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/);
 
     const results = subqueries.map(async (subquery, index) => {
       const response = this._client.query(subquery + ";", []);

--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -52,7 +52,7 @@ export class SQLite3Connector implements Connector {
     await this._makeConnection();
 
     const query = this._translator.translateToQuery(queryDescription);
-    const subqueries = query.split(";");
+    const subqueries = query.split(/(?<!\\);/);
 
     const results = subqueries.map(async (subquery, index) => {
       const response = this._client.query(subquery + ";", []);


### PR DESCRIPTION
Hi! I found a solution to the issue #128. 

I just replaced the statement ```split(';')``` to this regex ```/(?<!\\);/```. That avoid to the function to split a query if the semicolon was escaped. I also make a pull request to Dex to make the escape of semicolon by "default". 