### PR TITLE
Fix find method for mongodb

### DIFF
--- a/lib/query-builder.ts
+++ b/lib/query-builder.ts
@@ -135,10 +135,18 @@ export class QueryBuilder {
 
   find(field: string, possibleValues: FieldValue[]) {
     this._query.type = "select";
-    this._query.whereIn = {
-      field,
-      possibleValues,
-    };
+    
+    if (possibleValues.length === 1) {
+      this._query.values = {
+        [field]: possibleValues[0]
+      }
+    } else {
+      this._query.whereIn = {
+        field,
+        possibleValues,
+      };
+    }
+    
     return this;
   }
 


### PR DESCRIPTION
Hi! I found a new issue and already created possible solutions for it.

It turns out that find method for MongoDB always returned an `undefined` value. The solution was to change the `this._query.whereIn` to `this._query.values` if only array with single value is passed to the function.

I am not sure how this will behave witch other databases so if current tests doesn`t cover this method it should be checked manually.

While debugging app if I remember correctly, I spotted that `find` method is also involved `indirectly` through `create` method and there it seem to work fine so maybe the issue is somewhere deeper than I think.

Either way, please check this solution and let me known if is correct or not.