### PR TITLE
fix: belongsTo cyclic dependencies

### DIFF
--- a/lib/relationships.ts
+++ b/lib/relationships.ts
@@ -1,15 +1,20 @@
 import type { ModelSchema } from "./model.ts";
-import { DataTypes, FieldTypeString, RelationshipType } from "./data-types.ts";
+import { DataTypes, RelationshipType } from "./data-types.ts";
 import { PivotModel } from "./model-pivot.ts";
 
-type RelationshipOptions = {
+type PrimaryKeyOption = {
   primaryKey?: string;
+};
+
+type ForeignKeyOption = {
   foreignKey?: string;
 };
 
+type RelationshipOptions = PrimaryKeyOption & ForeignKeyOption;
+
 export const Relationships = {
-  /** Define a one-to-one or one-to-many relationship for a given model. */
-  belongsTo(model: ModelSchema): RelationshipType {
+  /** Define a one-to-one or one-to-many relationship field for a given model. */
+  _belongsToField(model: ModelSchema): RelationshipType {
     return {
       type: DataTypes.INTEGER,
       relationship: {
@@ -19,19 +24,31 @@ export const Relationships = {
     };
   },
 
+  /** Define a one-to-one or one-to-many relationship for a given model. */
+  belongsTo(
+    modelA: ModelSchema,
+    modelB: ModelSchema,
+    options?: PrimaryKeyOption,
+  ) {
+    const primaryKey = options.primaryKey;
+    const modelAFieldName = primaryKey || `${modelB.name.toLowerCase()}Id`;
+    modelA.fields[modelAFieldName] = this._belongsToField(modelB);
+  },
+
   /** Add corresponding fields to each model for a one-to-one relationship. */
   oneToOne(
     modelA: ModelSchema,
     modelB: ModelSchema,
     options?: RelationshipOptions,
   ) {
-    let primaryKey = options?.primaryKey;
-    let foreignKey = options?.foreignKey;
+    const primaryKey = options?.primaryKey;
+    const foreignKey = options?.foreignKey;
 
-    modelA.fields[primaryKey || `${modelB.name.toLowerCase()}Id`] = this
-      .belongsTo(modelB);
-    modelB.fields[foreignKey || `${modelA.name.toLowerCase()}Id`] = this
-      .belongsTo(modelA);
+    const modelAFieldName = primaryKey || `${modelB.name.toLowerCase()}Id`;
+    const modelBFieldName = foreignKey || `${modelA.name.toLowerCase()}Id`;
+
+    modelA.fields[modelAFieldName] = this._belongsToField(modelB);
+    modelB.fields[modelBFieldName] = this._belongsToField(modelA);
   },
 
   /** Generate a many-to-many pivot model for two given models.
@@ -43,8 +60,8 @@ export const Relationships = {
     modelB: ModelSchema,
     options?: RelationshipOptions,
   ): ModelSchema {
-    let primaryKey = options?.primaryKey;
-    let foreignKey = options?.foreignKey;
+    const primaryKey = options?.primaryKey;
+    const foreignKey = options?.foreignKey;
 
     const pivotClassName = `${modelA.table}_${modelB.table}`;
     const modelAFieldName = primaryKey || `${modelA.name.toLowerCase()}Id`;
@@ -58,8 +75,8 @@ export const Relationships = {
           primaryKey: true,
           autoIncrement: true,
         },
-        [modelAFieldName]: Relationships.belongsTo(modelA),
-        [modelBFieldName]: Relationships.belongsTo(modelB),
+        [modelAFieldName]: Relationships._belongsToField(modelA),
+        [modelBFieldName]: Relationships._belongsToField(modelB),
       };
 
       static _pivotsModels = {

--- a/lib/relationships.ts
+++ b/lib/relationships.ts
@@ -30,7 +30,7 @@ export const Relationships = {
     modelB: ModelSchema,
     options?: PrimaryKeyOption,
   ) {
-    const primaryKey = options.primaryKey;
+    const primaryKey = options?.primaryKey;
     const modelAFieldName = primaryKey || `${modelB.name.toLowerCase()}Id`;
     modelA.fields[modelAFieldName] = this._belongsToField(modelB);
   },

--- a/tests/units/Relationships/foreignkey.test.ts
+++ b/tests/units/Relationships/foreignkey.test.ts
@@ -25,13 +25,14 @@ class Business extends Model {
       primaryKey: true,
     },
     name: DataTypes.STRING,
-    ownerId: Relationships.belongsTo(Owner),
   };
 
   static owner() {
     return this.hasOne(Owner);
   }
 }
+
+Relationships.belongsTo(Business, Owner);
 
 Deno.test("MySQL: Foreign key test", async function () {
   const connection = getMySQLConnection();


### PR DESCRIPTION
Fix #105.

This addresses cyclic dependencies when models are declared in separated files but import one another in order to create associations.

As `belongsTo` was the only type of relationship working this way, it made sense to harmonize the API.