### PR TITLE
feat: add bigint support for primary key

### DIFF
--- a/lib/helpers/fields.ts
+++ b/lib/helpers/fields.ts
@@ -30,7 +30,7 @@ export function addFieldToSchema(
         .model
         .getComputedPrimaryType();
 
-      if (relationshipPKType === "integer") {
+      if (relationshipPKType === "integer" || relationshipPKType === "bigInteger") {
         const foreignField = table[relationshipPKType](fieldOptions.name);
 
         if (!relationshipPKProps.allowNull) {
@@ -76,7 +76,7 @@ export function addFieldToSchema(
     }
 
     if (fieldOptions.type.autoIncrement) {
-      instruction = table.increments(fieldOptions.name);
+      instruction = fieldOptions.type.type === "bigInteger" ? table.bigincrements(fieldOptions.name) : table.increments(fieldOptions.name);
     } else {
       instruction = table[type](...fieldNameArgs);
     }
@@ -95,11 +95,11 @@ export function addFieldToSchema(
   } else {
     instruction = table[type](fieldOptions.name);
   }
-  
+
   if (typeof fieldOptions.type === "object" && fieldOptions.type.comment) {
     instruction.comment(fieldOptions.type.comment);
   }
-  
+
   if (typeof fieldOptions.defaultValue !== "undefined") {
     instruction.defaultTo(fieldOptions.defaultValue);
   }


### PR DESCRIPTION
As the original code. If the primary key is both `DataTypes.BIG_INTEGER` and `autoIncrement`,  the column generated is `int unsigned` but not `bigint unsigned`

eq:
``` typescript
class Category extends Model {
  static table = "category";
  static timestamps = true;
  static fields = {
    id: { type: DataTypes.BIG_INTEGER, primaryKey: true, autoIncrement: true },
    name: { type: DataTypes.STRING, length: 100, unique: true, allowNull: false, comment: "Name" },
  };
}
```

Will generate: 
```sql
CREATE TABLE `category` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `name` varchar(100) NOT NULL COMMENT 'Name',
  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`),
  UNIQUE KEY `name` (`name`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
```
