### PR TITLE
Feat add transactions

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -11,7 +11,7 @@ export {
   Connection as MySQLConnection,
 } from "https://deno.land/x/mysql@v2.8.0/mod.ts";
 
-export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.4.6/mod.ts";
+export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.11.1/mod.ts";
 
 export { DB as SQLiteClient } from "https://deno.land/x/sqlite@v2.3.1/mod.ts";
 

--- a/lib/connectors/connector.ts
+++ b/lib/connectors/connector.ts
@@ -34,7 +34,7 @@ export interface Connector {
   query(queryDescription: QueryDescription): Promise<any | any[]>;
 
   /** Execute queries within a transaction on the database instance. */
-  transaction?(queries: QueryDescription[]): Promise<any | any[]>;
+  transaction?(queries: () => Promise<void>): Promise<void>;
 
   /** Disconnect from the external database instance. */
   close(): Promise<any>;

--- a/lib/connectors/mysql-connector.ts
+++ b/lib/connectors/mysql-connector.ts
@@ -51,7 +51,7 @@ export class MySQLConnector implements Connector {
     try {
       const [{ result }] = await this._client.query("SELECT 1 + 1 as result");
       return result === 2;
-    } catch (error) {
+    } catch {
       return false;
     }
   }

--- a/lib/connectors/mysql-connector.ts
+++ b/lib/connectors/mysql-connector.ts
@@ -78,22 +78,8 @@ export class MySQLConnector implements Connector {
     }
   }
 
-  async transaction(queries: QueryDescription[]): Promise<any | any[]> {
-    if (queries.length === 0) {
-      return [];
-    }
-
-    const results = await this._client.transaction(async (transaction) => {
-      const lastQuery = queries.pop()!;
-
-      for (const query of queries) {
-        await this.query(query, transaction);
-      }
-
-      return this.query(lastQuery, transaction);
-    });
-
-    return results as any;
+  transaction(queries: () => Promise<void>) {
+    return this._client.transaction(queries);
   }
 
   async close() {

--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -24,7 +24,7 @@ export class SQLite3Connector implements Connector {
     this._translator = new SQLTranslator(this._dialect);
   }
 
-  async _makeConnection() {
+  _makeConnection() {
     if (this._connected) {
       return;
     }
@@ -32,8 +32,8 @@ export class SQLite3Connector implements Connector {
     this._connected = true;
   }
 
-  async ping() {
-    await this._makeConnection();
+  ping() {
+    this._makeConnection();
 
     try {
       let connected = false;
@@ -42,14 +42,14 @@ export class SQLite3Connector implements Connector {
         connected = result === 2;
       }
 
-      return connected;
-    } catch (error) {
-      return false;
+      return Promise.resolve(connected);
+    } catch {
+      return Promise.resolve(false);
     }
   }
 
-  async query(queryDescription: QueryDescription): Promise<any | any[]> {
-    await this._makeConnection();
+  query(queryDescription: QueryDescription): Promise<any | any[]> {
+    this._makeConnection();
 
     const query = this._translator.translateToQuery(queryDescription);
     const subqueries = query.split(";");
@@ -67,7 +67,7 @@ export class SQLite3Connector implements Connector {
 
       try {
         columns = response.columns();
-      } catch (error) {
+      } catch {
         // If there are no matching records, .columns will throw an error
 
         if (
@@ -135,10 +135,11 @@ export class SQLite3Connector implements Connector {
 
   close() {
     if (!this._connected) {
-      return;
+      return Promise.resolve();
     }
 
     this._client.close();
     this._connected = false;
+    return Promise.resolve();
   }
 }

--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -129,7 +129,7 @@ export class SQLite3Connector implements Connector {
       this._client.query("commit");
     } catch (error) {
       this._client.query("rollback");
-      console.log(error);
+      throw error;
     }
   }
 

--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -121,7 +121,19 @@ export class SQLite3Connector implements Connector {
     return results[results.length - 1];
   }
 
-  async close() {
+  async transaction(queries: () => Promise<void>) {
+    this._client.query("begin");
+
+    try {
+      await queries();
+      this._client.query("commit");
+    } catch (error) {
+      this._client.query("rollback");
+      console.log(error);
+    }
+  }
+
+  close() {
     if (!this._connected) {
       return;
     }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -126,7 +126,7 @@ export class Database {
   private static _convertDialectFormToConnectorForm(
     dialectOptionsOrDatabaseOptions: DialectDatabaseOptions,
     connectionOptions: ConnectorOptions,
-    fromConstructor: boolean = true,
+    fromConstructor = true,
   ): ConnectorDatabaseOptions {
     if (typeof dialectOptionsOrDatabaseOptions === "string") {
       dialectOptionsOrDatabaseOptions = {
@@ -137,7 +137,7 @@ export class Database {
       fromConstructor &&
       !dialectOptionsOrDatabaseOptions.disableDialectUsageDeprecationWarning
     ) {
-      console.warn(
+      warning(
         "[denodb]: DEPRECATION warning, the usage with dialect instead of connector is deprecated and will be removed in future versions.\n" +
           "[denodb]: If you want to disable this warning pass `disableDialectUsageDeprecationWarning: true` with the dialect in the Database constructor.\n" +
           "[denodb]: If you want to migrate to the current behavior, visit https://github.com/eveningkid/denodb/blob/master/docs/v1.0.21-migrations/connectors.md for help",
@@ -171,12 +171,12 @@ export class Database {
 
   /** Test database connection. */
   ping() {
-    return this._connector.ping();
+    return this.getConnector().ping();
   }
 
   /** Get the database dialect. */
   getDialect() {
-    return this._connector?._dialect;
+    return this.getConnector()._dialect;
   }
 
   /* Get the database connector. */
@@ -237,7 +237,7 @@ export class Database {
       console.log(query);
     }
 
-    const results = await this._connector.query(query);
+    const results = await this.getConnector().query(query);
 
     return Array.isArray(results)
       ? results.map((result) =>
@@ -303,7 +303,7 @@ export class Database {
   }
 
   /** Close the current database connection. */
-  async close() {
-    return this._connector.close();
+  close() {
+    return this.getConnector().close();
   }
 }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -248,9 +248,7 @@ export class Database {
 
   /** Execute queries within a transaction. */
   transaction(queries: () => Promise<void>) {
-    const callTransactions = this.getConnector().transaction;
-
-    if (!callTransactions) {
+    if (!this.getConnector().transaction) {
       warning(
         "Transactions are not supported by this connector at the moment.",
       );
@@ -258,7 +256,7 @@ export class Database {
       return Promise.resolve();
     }
 
-    return callTransactions(queries);
+    return this.getConnector().transaction?.(queries);
   }
 
   /** Compute field matchings tables for model usage. */

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -81,7 +81,7 @@ export class Model {
   static pivot: ModelPivotModels = {};
 
   /** If the model has been created in the database. */
-  private static _isCreatedInDatabase: boolean = false;
+  private static _isCreatedInDatabase = false;
 
   /** Query builder instance. */
   private static _queryBuilder: QueryBuilder;
@@ -382,7 +382,7 @@ export class Model {
   }
 
   /** Run the current query. */
-  static async get() {
+  static get() {
     return this._runQuery(
       this._currentQuery.table(this.table).get().toDescription(),
     );
@@ -394,7 +394,7 @@ export class Model {
    *
    *     await Flight.select("id").all();
    */
-  static async all() {
+  static all() {
     return this.get() as Promise<Model[]>;
   }
 
@@ -621,7 +621,7 @@ export class Model {
    *
    *     await Flight.where("departure", "Dublin").update({ destination: "Tokyo" });
    */
-  static async update(fieldOrFields: string | Values, fieldValue?: FieldValue) {
+  static update(fieldOrFields: string | Values, fieldValue?: FieldValue) {
     let fieldsToUpdate: Values = {};
 
     if (this.timestamps) {
@@ -655,7 +655,7 @@ export class Model {
    *
    *     await Flight.deleteById("1");
    */
-  static async deleteById(id: FieldValue) {
+  static deleteById(id: FieldValue) {
     return this._runQuery(
       this._currentQuery
         .table(this.table)
@@ -669,7 +669,7 @@ export class Model {
    *
    *     await Flight.where("destination", "Paris").delete();
    */
-  static async delete() {
+  static delete() {
     return this._runQuery(
       this._currentQuery.table(this.table).delete().toDescription(),
     );
@@ -756,7 +756,7 @@ export class Model {
    *
    *     await Flight.where("destination", "Dublin").count();
    */
-  static async count(field: string = "*") {
+  static async count(field = "*") {
     const value = await this._runQuery(
       this._currentQuery
         .table(this.table)
@@ -996,7 +996,7 @@ export class Model {
    *
    *     await flight.delete();
    */
-  async delete() {
+  delete() {
     const model = this.constructor as ModelSchema;
     const PKCurrentValue = this._getCurrentPrimaryKey();
 

--- a/lib/translators/sql-translator.ts
+++ b/lib/translators/sql-translator.ts
@@ -32,7 +32,7 @@ export class SQLTranslator implements Translator {
           // is used. Knex deprecated it as part of its library but in our case,
           // it actually makes sense. As this warning message should be ignored,
           // we override the `log.warn` method so it doesn't show up.
-          warn(message: string) {
+          warn() {
           },
         },
       },


### PR DESCRIPTION
Fix #204

This brings transactions to Deno:

```js
await db.transaction(async () => {
  await User.create({ name: "Hello", email: "hello@gmail.com" });
  throw new Error();
});

console.log(await User.count()); // 0 because an error was thrown (so it rollbacked)
```

```js
await db.transaction(async () => {
  await User.create({ name: "Hello", email: "hello@gmail.com" });
});

console.log(await User.count()); // 1 because there was no error :)
```

For now, they are supported on MySQL, MariaDB, SQLite and Postgres (not Mongo).