### PR TITLE
create subqueries by semicolons correctly (#128, #149)

### DIFF
--- a/lib/connectors/mysql-connector.ts
+++ b/lib/connectors/mysql-connector.ts
@@ -64,7 +64,7 @@ export class MySQLConnector implements Connector {
 
     const queryClient = client ?? this._client;
     const query = this._translator.translateToQuery(queryDescription);
-    const subqueries = query.split(";");
+    const subqueries = query.split(/;(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/);
     const queryMethod = query.toLowerCase().startsWith("select")
       ? "query"
       : "execute";

--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -52,7 +52,7 @@ export class SQLite3Connector implements Connector {
     await this._makeConnection();
 
     const query = this._translator.translateToQuery(queryDescription);
-    const subqueries = query.split(";");
+    const subqueries = query.split(/;(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/);
 
     const results = subqueries.map(async (subquery, index) => {
       const response = this._client.query(subquery + ";", []);


### PR DESCRIPTION
I think its time to handle these issues (#128, #149). I made a pull request before, but I closed it to work in other things. Check it out. 
I just added this regex: `/;(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/`. 