### PR TITLE
add: orWhere & andWhere methods

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -10,13 +10,13 @@ export {
   Client as MySQLClient,
   configLogger as configMySQLLogger,
   Connection as MySQLConnection,
-} from "https://deno.land/x/mysql@v2.8.0/mod.ts";
-export type { LoggerConfig } from "https://deno.land/x/mysql@v2.8.0/mod.ts";
+} from "https://deno.land/x/mysql@v2.10.0/mod.ts";
+export type { LoggerConfig } from "https://deno.land/x/mysql@v2.10.0/mod.ts";
 
 export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.11.2/mod.ts";
 
 export { DB as SQLiteClient } from "https://deno.land/x/sqlite@v2.3.1/mod.ts";
 
-export { MongoClient as MongoDBClient, Bson } from "https://deno.land/x/mongo@v0.22.0/mod.ts";
-export type { ConnectOptions as MongoDBClientOptions } from "https://deno.land/x/mongo@v0.22.0/mod.ts";
-export type { Database as MongoDBDatabase } from "https://deno.land/x/mongo@v0.22.0/src/database.ts";
+export { MongoClient as MongoDBClient, Bson } from "https://deno.land/x/mongo@v0.24.0/mod.ts";
+export type { ConnectOptions as MongoDBClientOptions } from "https://deno.land/x/mongo@v0.24.0/mod.ts";
+export type { Database as MongoDBDatabase } from "https://deno.land/x/mongo@v0.24.0/src/database.ts";

--- a/lib/connectors/mongodb-connector.ts
+++ b/lib/connectors/mongodb-connector.ts
@@ -1,4 +1,4 @@
-import { MongoDBClient, Bson } from "../../deps.ts";
+import { Bson, MongoDBClient } from "../../deps.ts";
 import type { MongoDBClientOptions, MongoDBDatabase } from "../../deps.ts";
 import type { Connector, ConnectorOptions } from "./connector.ts";
 import type { QueryDescription } from "../query-builder.ts";
@@ -146,13 +146,13 @@ export class MongoDBConnector implements Connector {
         const selectFields: Object[] = [];
 
         if (queryDescription.whereIn) {
-
           if (queryDescription.whereIn.field === "_id") {
-            queryDescription.whereIn.possibleValues = queryDescription.whereIn.possibleValues.map(
-              (value) => new Bson.ObjectId(value)
-            );
+            queryDescription.whereIn.possibleValues = queryDescription.whereIn
+              .possibleValues.map(
+                (value) => new Bson.ObjectId(value),
+              );
           }
-          
+
           wheres[queryDescription.whereIn.field] = {
             $in: queryDescription.whereIn.possibleValues,
           };

--- a/lib/data-types.ts
+++ b/lib/data-types.ts
@@ -75,7 +75,7 @@ export type FieldProps = {
 export type FieldType = FieldTypeString | FieldProps;
 
 export type FieldAlias = { [k: string]: string };
-export type FieldValue = number | string | boolean | Date | ObjectId | null ;
+export type FieldValue = number | string | boolean | Date | ObjectId | null;
 export type FieldOptions = {
   name: string;
   type: FieldType;

--- a/lib/helpers/fields.ts
+++ b/lib/helpers/fields.ts
@@ -30,7 +30,9 @@ export function addFieldToSchema(
         .model
         .getComputedPrimaryType();
 
-      if (relationshipPKType === "integer" || relationshipPKType === "bigInteger") {
+      if (
+        relationshipPKType === "integer" || relationshipPKType === "bigInteger"
+      ) {
         const foreignField = table[relationshipPKType](fieldOptions.name);
 
         if (!relationshipPKProps.allowNull) {
@@ -76,7 +78,9 @@ export function addFieldToSchema(
     }
 
     if (fieldOptions.type.autoIncrement) {
-      instruction = fieldOptions.type.type === "bigInteger" ? table.bigincrements(fieldOptions.name) : table.increments(fieldOptions.name);
+      instruction = fieldOptions.type.type === "bigInteger"
+        ? table.bigincrements(fieldOptions.name)
+        : table.increments(fieldOptions.name);
     } else {
       instruction = table[type](...fieldNameArgs);
     }

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -612,6 +612,7 @@ export class Model {
           this.formatFieldToDatabase(fieldOrFields) as string,
           whereOperator,
           whereValue,
+          "none",
         );
       }
     } else {
@@ -629,6 +630,121 @@ export class Model {
           this.formatFieldToDatabase(field) as string,
           "=",
           value,
+          "none",
+        );
+      }
+    }
+
+    return this;
+  }
+
+  /** Add an `and` clause to your query when `where` is present.
+   *
+   *     await Flight.where("id", ">", "1").andWhere("id", "<", 10).get();
+   */
+  static andWhere<T extends ModelSchema>(
+    this: T,
+    field: string,
+    fieldValue: FieldValue,
+  ): T;
+  static andWhere<T extends ModelSchema>(
+    this: T,
+    field: string,
+    operator: Operator,
+    fieldValue: FieldValue,
+  ): T;
+  static andWhere<T extends ModelSchema>(this: T, fields: Values): T;
+  static andWhere<T extends ModelSchema>(
+    this: T,
+    fieldOrFields: string | Values,
+    operatorOrFieldValue?: Operator | FieldValue,
+    fieldValue?: FieldValue,
+  ) {
+    if (typeof fieldOrFields === "string") {
+      const whereOperator: Operator = typeof fieldValue !== "undefined"
+        ? (operatorOrFieldValue as Operator)
+        : "=";
+
+      const whereValue: FieldValue = typeof fieldValue !== "undefined"
+        ? fieldValue
+        : (operatorOrFieldValue as FieldValue);
+
+      if (whereValue !== undefined) {
+        this._currentQuery.where(
+          this.formatFieldToDatabase(fieldOrFields) as string,
+          whereOperator,
+          whereValue,
+          "and",
+        );
+      }
+    } else {
+      for (const [field, value] of Object.entries(fieldOrFields)) {
+        if (value === undefined) {
+          continue;
+        }
+
+        this._currentQuery.where(
+          this.formatFieldToDatabase(field) as string,
+          "=",
+          value,
+          "and",
+        );
+      }
+    }
+
+    return this;
+  }
+
+  /** Add an `or` clause to your query when `where` is present.
+   *
+   *     await Flight.where("id", ">", "1").orWhere("id", "<", 10).get();
+   */
+  static orWhere<T extends ModelSchema>(
+    this: T,
+    field: string,
+    fieldValue: FieldValue,
+  ): T;
+  static orWhere<T extends ModelSchema>(
+    this: T,
+    field: string,
+    operator: Operator,
+    fieldValue: FieldValue,
+  ): T;
+  static orWhere<T extends ModelSchema>(this: T, fields: Values): T;
+  static orWhere<T extends ModelSchema>(
+    this: T,
+    fieldOrFields: string | Values,
+    operatorOrFieldValue?: Operator | FieldValue,
+    fieldValue?: FieldValue,
+  ) {
+    if (typeof fieldOrFields === "string") {
+      const whereOperator: Operator = typeof fieldValue !== "undefined"
+        ? (operatorOrFieldValue as Operator)
+        : "=";
+
+      const whereValue: FieldValue = typeof fieldValue !== "undefined"
+        ? fieldValue
+        : (operatorOrFieldValue as FieldValue);
+
+      if (whereValue !== undefined) {
+        this._currentQuery.where(
+          this.formatFieldToDatabase(fieldOrFields) as string,
+          whereOperator,
+          whereValue,
+          "or",
+        );
+      }
+    } else {
+      for (const [field, value] of Object.entries(fieldOrFields)) {
+        if (value === undefined) {
+          continue;
+        }
+
+        this._currentQuery.where(
+          this.formatFieldToDatabase(field) as string,
+          "=",
+          value,
+          "or",
         );
       }
     }
@@ -680,7 +796,7 @@ export class Model {
     return this._runQuery(
       this._currentQuery
         .table(this.table)
-        .where(this.getComputedPrimaryKey(), "=", id)
+        .where(this.getComputedPrimaryKey(), "=", id, "none")
         .delete()
         .toDescription(),
     );

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -612,7 +612,6 @@ export class Model {
           this.formatFieldToDatabase(fieldOrFields) as string,
           whereOperator,
           whereValue,
-          "none",
         );
       }
     } else {
@@ -630,7 +629,6 @@ export class Model {
           this.formatFieldToDatabase(field) as string,
           "=",
           value,
-          "none",
         );
       }
     }
@@ -796,7 +794,7 @@ export class Model {
     return this._runQuery(
       this._currentQuery
         .table(this.table)
-        .where(this.getComputedPrimaryKey(), "=", id, "none")
+        .where(this.getComputedPrimaryKey(), "=", id)
         .delete()
         .toDescription(),
     );

--- a/lib/query-builder.ts
+++ b/lib/query-builder.ts
@@ -18,7 +18,8 @@ export type QueryType =
   | "max"
   | "avg"
   | "sum";
-export type WhereMethod = "none" | "and" | "or";
+
+export type WhereMethod = "and" | "or" | undefined;
 
 export type JoinClause = {
   joinTable: string;
@@ -180,13 +181,13 @@ export class QueryBuilder {
     field: string,
     operator: Operator,
     value: FieldValue,
-    method: WhereMethod,
+    method?: WhereMethod,
   ) {
     if (!this._query.wheres) {
       this._query.wheres = [];
     }
 
-    const whereClause: WhereClause = {
+    const whereClause = {
       field,
       operator,
       value,

--- a/lib/query-builder.ts
+++ b/lib/query-builder.ts
@@ -18,6 +18,7 @@ export type QueryType =
   | "max"
   | "avg"
   | "sum";
+export type WhereMethod = "none" | "and" | "or";
 
 export type JoinClause = {
   joinTable: string;
@@ -29,6 +30,7 @@ export type WhereClause = {
   field: string;
   operator: Operator;
   value: FieldValue;
+  method: WhereMethod;
 };
 
 export type WhereInClause = {
@@ -178,15 +180,17 @@ export class QueryBuilder {
     field: string,
     operator: Operator,
     value: FieldValue,
+    method: WhereMethod,
   ) {
     if (!this._query.wheres) {
       this._query.wheres = [];
     }
 
-    const whereClause = {
+    const whereClause: WhereClause = {
       field,
       operator,
       value,
+      method,
     };
 
     const existingWhereForFieldIndex = this._query.wheres.findIndex((where) =>

--- a/lib/relationships.ts
+++ b/lib/relationships.ts
@@ -52,7 +52,7 @@ export const Relationships = {
   },
 
   /** Generate a many-to-many pivot model for two given models.
-   * 
+   *
    *     const AirportFlight = Relationships.manyToMany(Airport, Flight);
    */
   manyToMany(

--- a/lib/translators/sql-translator.ts
+++ b/lib/translators/sql-translator.ts
@@ -79,14 +79,6 @@ export class SQLTranslator implements Translator {
     if (query.wheres) {
       query.wheres.forEach((where) => {
         switch (where.method) {
-          case "none":
-            queryBuilder = queryBuilder.where(
-              where.field,
-              where.operator,
-              where.value,
-            );
-            break;
-
           case "and":
             queryBuilder = queryBuilder.andWhere(
               where.field,
@@ -102,6 +94,13 @@ export class SQLTranslator implements Translator {
               where.value,
             );
             break;
+
+          default:
+            queryBuilder = queryBuilder.where(
+              where.field,
+              where.operator,
+              where.value,
+            );
         }
       });
     }

--- a/lib/translators/sql-translator.ts
+++ b/lib/translators/sql-translator.ts
@@ -78,11 +78,31 @@ export class SQLTranslator implements Translator {
 
     if (query.wheres) {
       query.wheres.forEach((where) => {
-        queryBuilder = queryBuilder.where(
-          where.field,
-          where.operator,
-          where.value,
-        );
+        switch (where.method) {
+          case "none":
+            queryBuilder = queryBuilder.where(
+              where.field,
+              where.operator,
+              where.value,
+            );
+            break;
+
+          case "and":
+            queryBuilder = queryBuilder.andWhere(
+              where.field,
+              where.operator,
+              where.value,
+            );
+            break;
+
+          case "or":
+            queryBuilder = queryBuilder.orWhere(
+              where.field,
+              where.operator,
+              where.value,
+            );
+            break;
+        }
       });
     }
 

--- a/tests/connection.ts
+++ b/tests/connection.ts
@@ -1,5 +1,5 @@
 import { config } from "https://deno.land/x/dotenv/mod.ts";
-import { Database } from "../mod.ts";
+import { Database, SQLite3Connector } from "../mod.ts";
 
 const env = config();
 
@@ -11,8 +11,8 @@ const defaultMySQLOptions = {
   port: Number(env.DB_PORT),
 };
 
-const defaultSQLiteOptions = {
-  filepath: "test.db",
+const defaultSQLitePath = {
+  filepath: "test.sqlite"
 };
 
 const getMySQLConnection = (options = {}, debug = true): Database => {
@@ -28,15 +28,11 @@ const getMySQLConnection = (options = {}, debug = true): Database => {
 };
 
 const getSQLiteConnection = (options = {}, debug = true): Database => {
-  const connection: Database = new Database(
-    { dialect: "sqlite3", debug },
-    {
-      ...defaultSQLiteOptions,
-      ...options,
-    },
-  );
+  const connection = new SQLite3Connector(defaultSQLitePath);
 
-  return connection;
+  const database = new Database(connection);
+
+  return database;
 };
 
 export { getMySQLConnection, getSQLiteConnection };

--- a/tests/units/clauses/andWhere.test.ts
+++ b/tests/units/clauses/andWhere.test.ts
@@ -1,0 +1,54 @@
+import { DataTypes, Model } from "../../../mod.ts";
+import { getSQLiteConnection } from "../../connection.ts";
+import { assertEquals } from "../../deps.ts";
+
+class User extends Model {
+  static table = "users";
+
+  static fields = {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: DataTypes.STRING,
+    age: DataTypes.INTEGER,
+  };
+}
+
+async function createConnection() {
+  const connection = getSQLiteConnection({}, false);
+
+  connection.link([User]);
+
+  await connection.sync({ drop: true });
+
+  return connection;
+}
+
+Deno.test("Model.andWhere()", async () => {
+  const conn = await createConnection();
+
+  await User.create({
+    name: "User",
+    age: 23,
+  });
+
+  await User.create({
+    name: "User",
+    age: 40,
+  });
+
+  const users = await User
+    .select("id")
+    .where({ name: "User" })
+    .andWhere({ age: 40 })
+    .get();
+
+  await conn.close();
+
+  assertEquals(
+    JSON.stringify(users),
+    JSON.stringify([{ id: 2 }]),
+  );
+});

--- a/tests/units/clauses/orWhere.test.ts
+++ b/tests/units/clauses/orWhere.test.ts
@@ -17,7 +17,7 @@ class User extends Model {
 }
 
 async function createConnection() {
-  const connection = getSQLiteConnection("test.db", false);
+  const connection = getSQLiteConnection({}, false);
 
   connection.link([User]);
 

--- a/tests/units/clauses/orWhere.test.ts
+++ b/tests/units/clauses/orWhere.test.ts
@@ -1,0 +1,54 @@
+import { DataTypes, Model } from "../../../mod.ts";
+import { getSQLiteConnection } from "../../connection.ts";
+import { assertEquals } from "../../deps.ts";
+
+class User extends Model {
+  static table = "users";
+
+  static fields = {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: DataTypes.STRING,
+    age: DataTypes.INTEGER,
+  };
+}
+
+async function createConnection() {
+  const connection = getSQLiteConnection("test.db", false);
+
+  connection.link([User]);
+
+  await connection.sync({ drop: true });
+
+  return connection;
+}
+
+Deno.test("Model.orWhere()", async () => {
+  const conn = await createConnection();
+
+  await User.create({
+    name: "User name 1",
+    age: 23,
+  });
+
+  await User.create({
+    name: "User name 2",
+    age: 40,
+  });
+
+  const users = await User
+    .select("id")
+    .where({ name: "User name 1" })
+    .orWhere({ age: 40 })
+    .get();
+
+  await conn.close();
+
+  assertEquals(
+    JSON.stringify(users),
+    JSON.stringify([{ id: 1 }, { id: 2 }]),
+  );
+});

--- a/tests/units/clauses/where.test.ts
+++ b/tests/units/clauses/where.test.ts
@@ -1,0 +1,48 @@
+import { DataTypes, Model } from "../../../mod.ts";
+import { getSQLiteConnection } from "../../connection.ts";
+import { assertEquals } from "../../deps.ts";
+
+class User extends Model {
+  static table = "users";
+
+  static fields = {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: DataTypes.STRING,
+    age: DataTypes.INTEGER,
+  };
+}
+
+async function createConnection() {
+  const connection = getSQLiteConnection({}, false);
+
+  connection.link([User]);
+
+  await connection.sync({ drop: true });
+
+  return connection;
+}
+
+Deno.test("Model.where()", async () => {
+  const conn = await createConnection();
+
+  await User.create({
+    name: "User",
+    age: 23,
+  });
+
+  const users = await User
+    .select("id")
+    .where({ name: "User" })
+    .first();
+
+  await conn.close();
+
+  assertEquals(
+    JSON.stringify(users),
+    JSON.stringify({ id: 1 }),
+  );
+});


### PR DESCRIPTION
I added the orWhere and andWhere methods. I read your comment about a cool API to add these clauses like "automatically", but I thing that this is a good temportal solution. The query or & and are very usefull and denodb has to include them (also to close issue #197)

Ah, in addition, I left a little issue (#280) about a weird behavior, I hope you can check it out! 