### PR TITLE
Upgrade to mysql@2.10.0

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -10,8 +10,8 @@ export {
   Client as MySQLClient,
   configLogger as configMySQLLogger,
   Connection as MySQLConnection,
-} from "https://deno.land/x/mysql@v2.8.0/mod.ts";
-export type { LoggerConfig } from "https://deno.land/x/mysql@v2.8.0/mod.ts";
+} from "https://deno.land/x/mysql@v2.10.0/mod.ts";
+export type { LoggerConfig } from "https://deno.land/x/mysql@v2.10.0/mod.ts";
 
 export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.11.2/mod.ts";
 

--- a/deps.ts
+++ b/deps.ts
@@ -17,6 +17,9 @@ export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.11.2/m
 
 export { DB as SQLiteClient } from "https://deno.land/x/sqlite@v2.3.1/mod.ts";
 
+// NOTE(eveningkid): upgrading to 0.24.0 would raise an issue asking for the --unstable flag.
+// This would be asked to anyone using denodb, not only mongodb users.
+// Should wait on a version that isn't using any unstable API
 export { MongoClient as MongoDBClient, Bson } from "https://deno.land/x/mongo@v0.22.0/mod.ts";
 export type { ConnectOptions as MongoDBClientOptions } from "https://deno.land/x/mongo@v0.22.0/mod.ts";
 export type { Database as MongoDBDatabase } from "https://deno.land/x/mongo@v0.22.0/src/database.ts";


### PR DESCRIPTION
Fix #289.

- Upgrade MySQL driver to `2.10.0` since it would raise an issue: https://github.com/denodrivers/mysql/issues/117
- Add note on why we're not upgrading the MongoDB driver yet. denodb should not use any unstable APIs for now since it would impact every single user, including the ones not using MongoDB