### PR TITLE
Update dex, sqlite, mysql, mongodb, postgres deps for compatibility with the latest deno v1.16.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ examples/
 .deno_plugins
 .nova/*
 tsconfig.json
+.env

--- a/deps.ts
+++ b/deps.ts
@@ -1,8 +1,7 @@
 export * as ConsoleColor from "https://deno.land/x/colorlog@v1.0/mod.ts";
 
-// NOTE(eveningkid): this has not be versioned because the Github releases are not up-to-date.
-// Only master is valid at the moment. Seems safe for now since there is no commits being added
-export { default as SQLQueryBuilder } from "https://raw.githubusercontent.com/aghussb/dex/master/mod.ts";
+// NOTE: these changes fixes #303.
+export { default as SQLQueryBuilder } from "https://raw.githubusercontent.com/Zhomart/dex/c452c40b365e73265a25c18cb7adf5d35c1dbb8b/mod-dyn.ts";
 
 export { camelCase, snakeCase } from "https://deno.land/x/case@v2.1.0/mod.ts";
 
@@ -10,16 +9,13 @@ export {
   Client as MySQLClient,
   configLogger as configMySQLLogger,
   Connection as MySQLConnection,
-} from "https://deno.land/x/mysql@v2.10.0/mod.ts";
-export type { LoggerConfig } from "https://deno.land/x/mysql@v2.10.0/mod.ts";
+} from "https://deno.land/x/mysql@v2.10.1/mod.ts";
+export type { LoggerConfig } from "https://deno.land/x/mysql@v2.10.1/mod.ts";
 
-export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.11.2/mod.ts";
+export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.14.2/mod.ts";
 
-export { DB as SQLiteClient } from "https://deno.land/x/sqlite@v2.3.1/mod.ts";
+export { DB as SQLiteClient } from "https://deno.land/x/sqlite@v3.1.3/mod.ts";
 
-// NOTE(eveningkid): upgrading to 0.24.0 would raise an issue asking for the --unstable flag.
-// This would be asked to anyone using denodb, not only mongodb users.
-// Should wait on a version that isn't using any unstable API
-export { MongoClient as MongoDBClient, Bson } from "https://deno.land/x/mongo@v0.22.0/mod.ts";
-export type { ConnectOptions as MongoDBClientOptions } from "https://deno.land/x/mongo@v0.22.0/mod.ts";
-export type { Database as MongoDBDatabase } from "https://deno.land/x/mongo@v0.22.0/src/database.ts";
+export { MongoClient as MongoDBClient, Bson } from "https://deno.land/x/mongo@v0.28.0/mod.ts";
+export type { ConnectOptions as MongoDBClientOptions } from "https://deno.land/x/mongo@v0.28.0/mod.ts";
+export type { Database as MongoDBDatabase } from "https://deno.land/x/mongo@v0.28.0/src/database.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,7 +1,8 @@
 export * as ConsoleColor from "https://deno.land/x/colorlog@v1.0/mod.ts";
 
-// NOTE: these changes fixes #303.
-export { default as SQLQueryBuilder } from "https://raw.githubusercontent.com/Zhomart/dex/c452c40b365e73265a25c18cb7adf5d35c1dbb8b/mod-dyn.ts";
+// NOTE: Migrate to the official https://github.com/aghussb/dex when it's updated to the
+//       latest deno version.
+export { default as SQLQueryBuilder } from "https://raw.githubusercontent.com/Zhomart/dex/930253915093e1e08d48ec0409b4aee800d8bd0c/mod-dyn.ts";
 
 export { camelCase, snakeCase } from "https://deno.land/x/case@v2.1.0/mod.ts";
 
@@ -16,6 +17,6 @@ export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.14.2/m
 
 export { DB as SQLiteClient } from "https://deno.land/x/sqlite@v3.1.3/mod.ts";
 
-export { MongoClient as MongoDBClient, Bson } from "https://deno.land/x/mongo@v0.28.0/mod.ts";
-export type { ConnectOptions as MongoDBClientOptions } from "https://deno.land/x/mongo@v0.28.0/mod.ts";
-export type { Database as MongoDBDatabase } from "https://deno.land/x/mongo@v0.28.0/src/database.ts";
+export { MongoClient as MongoDBClient, Bson } from "https://deno.land/x/mongo@v0.28.1/mod.ts";
+export type { ConnectOptions as MongoDBClientOptions } from "https://deno.land/x/mongo@v0.28.1/mod.ts";
+export type { Database as MongoDBDatabase } from "https://deno.land/x/mongo@v0.28.1/src/database.ts";

--- a/lib/connectors/mysql-connector.ts
+++ b/lib/connectors/mysql-connector.ts
@@ -65,6 +65,7 @@ export class MySQLConnector implements Connector {
   async query(
     queryDescription: QueryDescription,
     client?: MySQLClient | MySQLConnection,
+  // deno-lint-ignore no-explicit-any
   ): Promise<any | any[]> {
     await this._makeConnection();
 

--- a/lib/connectors/postgres-connector.ts
+++ b/lib/connectors/postgres-connector.ts
@@ -59,7 +59,7 @@ export class PostgresConnector implements Connector {
     await this._makeConnection();
 
     try {
-      const [{ result }] = (
+      const [result] = (
         await this._client.queryObject("SELECT 1 + 1 as result")
       ).rows;
       return result === 2;
@@ -68,6 +68,7 @@ export class PostgresConnector implements Connector {
     }
   }
 
+  // deno-lint-ignore no-explicit-any
   async query(queryDescription: QueryDescription): Promise<any | any[]> {
     await this._makeConnection();
 

--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -55,8 +55,7 @@ export class SQLite3Connector implements Connector {
     const query = this._translator.translateToQuery(queryDescription);
     const subqueries = query.split(/;(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/);
 
-    // deno-lint-ignore require-await
-    const results = subqueries.map(async (subquery, index) => {
+    const results = subqueries.map((subquery, index) => {
       const preparedQuery = this._client.prepareQuery(subquery + ";");
       const response = preparedQuery.allEntries();
       preparedQuery.finalize();
@@ -84,7 +83,7 @@ export class SQLite3Connector implements Connector {
         const result: Record<string, FieldValue> = {};
         for (const [columnName, value] of Object.entries(row)) {
           if (columnName === "count(*)") {
-            result.count = row[columnName] as FieldValue;
+            result.count = value as FieldValue;
           } else if (columnName.startsWith("max(")) {
             result.max = value as FieldValue;
           } else if (columnName.startsWith("min(")) {
@@ -101,7 +100,7 @@ export class SQLite3Connector implements Connector {
       });
     });
 
-    return results[results.length - 1];
+    return Promise.resolve(results[results.length - 1]);
   }
 
   async transaction(queries: () => Promise<void>) {

--- a/tests/connection.ts
+++ b/tests/connection.ts
@@ -12,7 +12,7 @@ const defaultMySQLOptions = {
 };
 
 const defaultSQLiteOptions = {
-  filepath: "test.db",
+  filepath: "test.sqlite",
 };
 
 const getMySQLConnection = (options = {}, debug = true): Database => {

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -1,1 +1,1 @@
-export { assertEquals } from "https://deno.land/std@0.56.0/testing/asserts.ts";
+export { assertEquals } from "https://deno.land/std@0.115.1/testing/asserts.ts";

--- a/tests/units/queries/sqlite/response.test.ts
+++ b/tests/units/queries/sqlite/response.test.ts
@@ -84,6 +84,10 @@ Deno.test("SQLite: Response model", async () => {
     "Update many records response",
   );
 
+  const articleCount = await Article.where({ title: "hola mundo!" }).count();
+
+  assertEquals(articleCount, 2, "Return article count");
+
   const deleteManyResponse = await Article.where({ title: "hola mundo!" })
     .delete();
 


### PR DESCRIPTION
Update dex, sqlite, mysql, mongodb, postgres deps for compatibility with the latest deno v1.16.2

- dex: update to the version that uses std@0.115.1, instead
     of the latest version of jspm-core, which could be dangerous
     when jspm-core pushes the latest breaking code.
     aghussb/dex#3
- sqlite: update to v3.1.3, it contains breaking changes
        so this PR fixes them too.
- mysql: minor upgrade to v2.10.1 (from v2.10.0)
- mongodb: update to v0.28.0, because the old version
         is not compatible with the latest deno.
- postgres: update to v0.14.2 and fix postgres-connectors.ts,
          because the old version is not compatible with the latest deno.

The changes are tested on deno v1.16.2.

Fixes: #303, #302