### PR TITLE
Updated tests to use connector syntax

### DIFF
--- a/tests/connection.ts
+++ b/tests/connection.ts
@@ -1,5 +1,5 @@
 import { config } from "https://deno.land/x/dotenv/mod.ts";
-import { Database } from "../mod.ts";
+import { Database, MySQLConnector, SQLite3Connector } from "../mod.ts";
 
 const env = config();
 
@@ -16,25 +16,21 @@ const defaultSQLiteOptions = {
 };
 
 const getMySQLConnection = (options = {}, debug = true): Database => {
-  const connection: Database = new Database(
-    { dialect: "mysql", debug },
-    {
-      ...defaultMySQLOptions,
-      ...options,
-    },
-  );
+  const connector = new MySQLConnector({
+    ...defaultMySQLOptions,
+    ...options,
+  });
+  const connection: Database = new Database({ connector, debug });
 
   return connection;
 };
 
 const getSQLiteConnection = (options = {}, debug = true): Database => {
-  const connection: Database = new Database(
-    { dialect: "sqlite3", debug },
-    {
-      ...defaultSQLiteOptions,
-      ...options,
-    },
-  );
+  const connector = new SQLite3Connector({
+    ...defaultSQLiteOptions,
+    ...options,
+  });
+  const connection: Database = new Database({ connector, debug });
 
   return connection;
 };


### PR DESCRIPTION
Running tests gives deprecated warnings.

```
λ deno test --allow-env --allow-read --allow-net --allow-write
running 1 test from file:///.../denodb/tests/units/Relationships/foreignkey.test.ts
test MySQL: Foreign key test ...[denodb]: DEPRECATION warning, the usage with dialect instead of connector is deprecated and will be removed in future versions.
[denodb]: If you want to disable this warning pass `disableDialectUsageDeprecationWarning: true` with the dialect in the Database constructor.
[denodb]: If you want to migrate to the current behavior, visit https://github.com/eveningkid/denodb/blob/master/docs/v1.0.21-migrations/connectors.md for help
INFO connecting 127.0.0.1:3306
INFO connected to 127.0.0.1:3306
INFO close connection
```