### PR TITLE
fix(#74): Updated constraint name

### DIFF
--- a/lib/helpers/fields.ts
+++ b/lib/helpers/fields.ts
@@ -82,11 +82,11 @@ export function addFieldToSchema(
     }
 
     if (fieldOptions.type.primaryKey) {
-      instruction = instruction.primary(fieldOptions.name);
+      instruction = instruction.primary(`constraint_${table._tableName}_${fieldOptions.name}_primary`);
     }
 
     if (fieldOptions.type.unique) {
-      instruction = instruction.unique(fieldOptions.name);
+      instruction = instruction.unique(`constraint_${table._tableName}_${fieldOptions.name}_unique`);
     }
 
     if (!fieldOptions.type.allowNull) {


### PR DESCRIPTION
Updated constraint name because of postgres throwing error on a property being set unique(duplicate constraint name). However only appending table name might not be completely right since a column might as well be having a name that could match table name_name. Hence added "constraint_" at the start 

Apologies for the references of commits on the issue. Was having issues with vim and keyboard