### PR TITLE
Add query-logger

### DIFF
--- a/lib/connectors/mysql-connector.ts
+++ b/lib/connectors/mysql-connector.ts
@@ -4,6 +4,7 @@ import type { Connector, ConnectorOptions } from "./connector.ts";
 import { SQLTranslator } from "../translators/sql-translator.ts";
 import type { SupportedSQLDatabaseDialect } from "../translators/sql-translator.ts";
 import type { QueryDescription } from "../query-builder.ts";
+import { QueryLogger } from "../query-logger.ts";
 
 export interface MySQLOptions extends ConnectorOptions {
   database: string;
@@ -67,6 +68,7 @@ export class MySQLConnector implements Connector {
     client?: MySQLClient | MySQLConnection,
   // deno-lint-ignore no-explicit-any
   ): Promise<any | any[]> {
+    const start = QueryLogger.start();
     await this._makeConnection();
 
     const queryClient = client ?? this._client;
@@ -80,6 +82,7 @@ export class MySQLConnector implements Connector {
       const result = await queryClient[queryMethod](subqueries[i]);
 
       if (i === subqueries.length - 1) {
+        QueryLogger.end(start, query);
         return result;
       }
     }

--- a/lib/connectors/sqlite3-connector.ts
+++ b/lib/connectors/sqlite3-connector.ts
@@ -1,6 +1,7 @@
 import { SQLiteClient } from "../../deps.ts";
 import type { Connector, ConnectorOptions } from "./connector.ts";
 import type { QueryDescription } from "../query-builder.ts";
+import { QueryLogger } from "../query-logger.ts";
 import type { FieldValue } from "../data-types.ts";
 import { SQLTranslator } from "../translators/sql-translator.ts";
 import type { SupportedSQLDatabaseDialect } from "../translators/sql-translator.ts";
@@ -50,6 +51,7 @@ export class SQLite3Connector implements Connector {
 
   // deno-lint-ignore no-explicit-any
   query(queryDescription: QueryDescription): Promise<any | any[]> {
+    const start = QueryLogger.start();
     this._makeConnection();
 
     const query = this._translator.translateToQuery(queryDescription);
@@ -65,6 +67,7 @@ export class SQLite3Connector implements Connector {
       }
 
       if (response.length === 0) {
+        QueryLogger.end(start, query);
         if (queryDescription.type === "insert" && queryDescription.values) {
           return {
             affectedRows: this._client.changes,
@@ -96,6 +99,7 @@ export class SQLite3Connector implements Connector {
             result[columnName] = value as FieldValue;
           }
         }
+        QueryLogger.end(start, query);
         return result;
       });
     });

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -6,6 +6,7 @@ import type {
   ModelSchema,
 } from "./model.ts";
 import { QueryBuilder, QueryDescription } from "./query-builder.ts";
+import { QueryLogger, LoggerOptions } from "./query-logger.ts";
 import { formatResultToModelInstance } from "./helpers/results.ts";
 import { Translator } from "./translators/translator.ts";
 import { connectorFactory } from "./connectors/factory.ts";
@@ -106,6 +107,10 @@ export class Database {
     }
 
     this._queryBuilder = new QueryBuilder();
+    const loggerOptions = connectionOptions as LoggerOptions;
+    if (typeof loggerOptions?.queryLogger === "function") {
+      QueryLogger.init(loggerOptions.queryLogger);
+    }
   }
 
   private static _isInDialectForm(

--- a/lib/query-logger.ts
+++ b/lib/query-logger.ts
@@ -1,0 +1,32 @@
+export type LogHandler = (query: string, execTime?: number) => void;
+export interface LoggerOptions {
+  queryLogger: LogHandler;
+}
+
+export class QueryLogger {
+  private static _single: QueryLogger;
+  private _logger: LogHandler;
+  constructor(logger: LogHandler) {
+    this._logger = logger;
+  }
+
+  static init(logger: LogHandler) {
+    if (this._single) {
+      return this._single;
+    }
+    this._single = new QueryLogger(logger);
+    return this._single;
+  }
+
+  static start(): Date {
+    const start = new Date();
+    return start;
+  }
+
+  static end(start: Date, query: string) {
+    if (!this._single) return;
+    const end = new Date();
+    const execTime = end.getTime() - start.getTime();
+    this._single._logger(query, execTime);
+  }
+}

--- a/tests/connection.ts
+++ b/tests/connection.ts
@@ -21,6 +21,9 @@ const getMySQLConnection = (options = {}, debug = true): Database => {
     {
       ...defaultMySQLOptions,
       ...options,
+      queryLogger : (query : string, execTime : number)=>{
+        console.log(`[${execTime} ms] ${query}`)
+      }
     },
   );
 
@@ -33,6 +36,9 @@ const getSQLiteConnection = (options = {}, debug = true): Database => {
     {
       ...defaultSQLiteOptions,
       ...options,
+      queryLogger : (query : string, execTime : number)=>{
+        console.log(`[${execTime} ms] ${query}`)
+      }
     },
   );
 


### PR DESCRIPTION
I have created a queryLogger option to the database for mysql, postgreSQL and sqlite.

[sequelize logging options](https://sequelize.org/v6/manual/getting-started.html#logging)

## example

### database
```
  const connection: Database = new Database(
    { dialect: "mysql" },
    {
      ...options,
      queryLogger : (query : string, execTime : number)=>{
        console.log(`[${execTime} ms] ${query}`)
      }
    },
  );
```


### code
```
const result = await Flight.where({ departure: "Paris" }).first();
```

### expected
```
[9 ms] select * from `flights` where `departure` = 'Paris' limit 1
```
