### PR TITLE
Fix postgres transactions

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -13,7 +13,7 @@ export {
 } from "https://deno.land/x/mysql@v2.10.1/mod.ts";
 export type { LoggerConfig } from "https://deno.land/x/mysql@v2.10.1/mod.ts";
 
-export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.14.2/mod.ts";
+export { Client as PostgresClient, Transaction as PostgresTransaction } from "https://deno.land/x/postgres@v0.14.2/mod.ts";
 
 export { DB as SQLiteClient } from "https://deno.land/x/sqlite@v3.1.3/mod.ts";
 


### PR DESCRIPTION
This needs a test, i dont know how to test this myself, but i will be happy to do so if someone explain me

The idea of this PR is:
We add a transaction property to the `PostgresConnector` class containing either a postgres `Trasaction` or `null`

When calling `transaction()` on the `PostgresConnector`, we create a transaction and update the `transaction` property
When the transaction as finished, we set the `transaction` property back to `null`

The method `query()` is modified to make the request with the transaction if any, otherwise it will use the `client`, as usual.