### PR TITLE
Support for Postgres Pooling

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,3 @@
+{
+    "importMap": "./import_map.json"
+}

--- a/deps.ts
+++ b/deps.ts
@@ -13,7 +13,8 @@ export {
 } from "https://deno.land/x/mysql@v2.10.1/mod.ts";
 export type { LoggerConfig } from "https://deno.land/x/mysql@v2.10.1/mod.ts";
 
-export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.14.2/mod.ts";
+export { Client as PostgresClient,Pool as PostgresPool } from "https://deno.land/x/postgres@v0.16.1/mod.ts";
+export type { ClientOptions as PostgresClientOptions, ConnectionString as PostgresConnectionString } from "https://deno.land/x/postgres@v0.16.1/mod.ts";
 
 export { DB as SQLiteClient } from "https://deno.land/x/sqlite@v3.1.3/mod.ts";
 

--- a/import_map.json
+++ b/import_map.json
@@ -1,13 +1,7 @@
 {
   "imports": {
-    "https://dev.jspm.io/npm:@jspm/core@1/nodelibs/timers.js": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/deno/timers.ts",
-    "https://dev.jspm.io/inherits@2.0": "https://ga.jspm.io/npm:inherits@2.0.4/inherits.js",
-    "https://dev.jspm.io/npm:@jspm/core@1/nodelibs/url.js": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/deno/url.ts",
-    "https://dev.jspm.io/npm:@jspm/core@1/nodelibs/events.js": "https://ga.jspm.io/npm:@jspm/core@1/nodelibs/node/events.ts"
-  },
-  "scopes": {
-    "https://ga.jspm.io/": {
-      "util": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/deno/util.ts"
-    }
+    "https://dev.jspm.io/npm:@jspm/core@1/nodelibs/timers.js": "https://deno.land/std@0.159.0/node/timers.ts",
+    "https://dev.jspm.io/npm:@jspm/core@1/nodelibs/url.js": "https://deno.land/std@0.159.0/node/url.ts",
+    "https://dev.jspm.io/npm:@jspm/core@1/nodelibs/events.js": "https://deno.land/std@0.159.0/node/events.ts"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,0 +1,13 @@
+{
+  "imports": {
+    "https://dev.jspm.io/npm:@jspm/core@1/nodelibs/timers.js": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/deno/timers.ts",
+    "https://dev.jspm.io/inherits@2.0": "https://ga.jspm.io/npm:inherits@2.0.4/inherits.js",
+    "https://dev.jspm.io/npm:@jspm/core@1/nodelibs/url.js": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/deno/url.ts",
+    "https://dev.jspm.io/npm:@jspm/core@1/nodelibs/events.js": "https://ga.jspm.io/npm:@jspm/core@1/nodelibs/node/events.ts"
+  },
+  "scopes": {
+    "https://ga.jspm.io/": {
+      "util": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/deno/util.ts"
+    }
+  }
+}

--- a/lib/connectors/connector.ts
+++ b/lib/connectors/connector.ts
@@ -2,10 +2,16 @@ import type { QueryDescription } from "../query-builder.ts";
 import { Translator } from "../translators/translator.ts";
 
 /** Default connector options. */
-export interface ConnectorOptions {}
+export interface ConnectorOptions { }
+
+/** Default pool options. */
+export interface ConnectorPoolOptions { }
 
 /** Default connector client. */
-export interface ConnectorClient {}
+export interface ConnectorClient { }
+
+/** Default connector pool. */
+export interface ConnectionPool { }
 
 /** Connector interface for a database provider connection. */
 export interface Connector {
@@ -16,19 +22,22 @@ export interface Connector {
   _translator: Translator;
 
   /** Client that maintains an external database connection. */
-  _client: ConnectorClient;
+  _client?: ConnectorClient | undefined;
 
   /** Options to connect to an external instance. */
   _options: ConnectorOptions;
 
   /** Is the client connected to an external instance. */
-  _connected: boolean;
+  _connected?: boolean | undefined;
+
+  /** Is the optional pool for making connections to an external instance. */
+  _pool?: ConnectionPool | undefined;
 
   /** Test connection. */
   ping(): Promise<boolean>;
 
   /** Connect to an external database instance. */
-  _makeConnection(): void;
+  _makeConnection(): void | ConnectorClient | Promise<void> | Promise<ConnectorClient>;
 
   /** Execute a query on the external database instance. */
   query(queryDescription: QueryDescription): Promise<any | any[]>;

--- a/lib/connectors/connector.ts
+++ b/lib/connectors/connector.ts
@@ -1,3 +1,4 @@
+import { PostgresPool } from "../../deps.ts";
 import type { QueryDescription } from "../query-builder.ts";
 import { Translator } from "../translators/translator.ts";
 
@@ -11,7 +12,7 @@ export interface ConnectorPoolOptions { }
 export interface ConnectorClient { }
 
 /** Default connector pool. */
-export interface ConnectionPool { }
+export interface ConnectionPool extends PostgresPool{ }
 
 /** Connector interface for a database provider connection. */
 export interface Connector {

--- a/lib/connectors/postgres-connector.ts
+++ b/lib/connectors/postgres-connector.ts
@@ -74,7 +74,9 @@ export class PostgresConnector implements Connector {
     }
     else {
       this._pool = new PostgresPool("uri" in options.connection_params ? options.connection_params.uri : {
-        ...options.connection_params
+        hostname: options.connection_params.host,
+        user: options.connection_params.username,
+        ...options.connection_params,
       },
         options.size,
         options.lazy
@@ -105,8 +107,8 @@ export class PostgresConnector implements Connector {
   async tryConnection(client?: PostgresClient) {
     try {
       const [result] = (
-        await client!.queryObject("SELECT 1 + 1 as result")
-      ).rows;
+        await client!.queryArray("SELECT 1 + 1 as result")
+      ).rows[0];
       return result === 2;
     } catch {
       return false;
@@ -140,9 +142,10 @@ export class PostgresConnector implements Connector {
         return;
       }
       await this._client.end();
-      this._connected = false;
     } else {
       await this._pool?.end()!
     }
+    this._connected = false;
   }
+
 }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -189,6 +189,11 @@ export class Database {
     return this.getConnector()._client;
   }
 
+  /* Get the database pool if existent. */
+  getPool?() {
+    return this.getConnector()._pool;
+  }
+
   /** Create the given models in the current database.
    *
    *     await db.sync({ drop: true });

--- a/tests/connection.ts
+++ b/tests/connection.ts
@@ -15,6 +15,18 @@ const defaultSQLiteOptions = {
   filepath: "test.sqlite",
 };
 
+const defaultPostgreSQLPoolOptions = {
+  connection_params: {
+    database: "test",
+    host: "127.0.0.1",
+    username: env.DB_USER,
+    password: env.DB_PASS,
+    port: Number(env.DB_PORT),
+  },
+  size: 5,
+  lazy: false
+};
+
 const getMySQLConnection = (options = {}, debug = true): Database => {
   const connection: Database = new Database(
     { dialect: "mysql", debug },
@@ -39,4 +51,16 @@ const getSQLiteConnection = (options = {}, debug = true): Database => {
   return connection;
 };
 
-export { getMySQLConnection, getSQLiteConnection };
+const getPostgreSQLPoolConnection = (options = {}, debug = true): Database => {
+  const connection: Database = new Database(
+    { dialect: "postgres", debug },
+    {
+      ...defaultPostgreSQLPoolOptions,
+      ...options,
+    },
+  );
+
+  return connection;
+};
+
+export { getMySQLConnection, getSQLiteConnection, getPostgreSQLPoolConnection };

--- a/tests/connection.ts
+++ b/tests/connection.ts
@@ -17,14 +17,14 @@ const defaultSQLiteOptions = {
 
 const defaultPostgreSQLPoolOptions = {
   connection_params: {
-    database: "test",
-    host: "127.0.0.1",
-    username: env.DB_USER,
-    password: env.DB_PASS,
-    port: Number(env.DB_PORT),
+    uri: "postgres://postgres:user@localhost:5432/test"
   },
-  size: 5,
+  size: 2,
   lazy: false
+};
+
+const defaultPostgreSQLOptions = {
+  uri: "postgres://postgres:user@localhost:5432/test"
 };
 
 const getMySQLConnection = (options = {}, debug = true): Database => {
@@ -63,4 +63,16 @@ const getPostgreSQLPoolConnection = (options = {}, debug = true): Database => {
   return connection;
 };
 
-export { getMySQLConnection, getSQLiteConnection, getPostgreSQLPoolConnection };
+const getPostgreSQLConnection = (options = {}, debug = true): Database => {
+  const connection: Database = new Database(
+    { dialect: "postgres", debug },
+    {
+      ...defaultPostgreSQLOptions,
+      ...options,
+    },
+  );
+
+  return connection;
+};
+
+export { getMySQLConnection, getSQLiteConnection, getPostgreSQLPoolConnection, getPostgreSQLConnection };

--- a/tests/units/connectors/postgres/connection.test.ts
+++ b/tests/units/connectors/postgres/connection.test.ts
@@ -1,8 +1,16 @@
-import { getPostgreSQLPoolConnection } from "../../../connection.ts";
+import { getPostgreSQLPoolConnection, getPostgreSQLConnection } from "../../../connection.ts";
 import { assertEquals } from "../../../deps.ts";
 
-Deno.test("PostgreSQL: Connection", async function () {
+Deno.test({ name: "PostgreSQL: Connection", sanitizeResources: false}, async function () {
   const connection = getPostgreSQLPoolConnection();
+  const ping = await connection.ping();
+  await connection.close();
+
+  assertEquals(ping, true);
+});
+
+Deno.test({ name: "PostgreSQL: Pool Connection", sanitizeResources: false}, async function () {
+  const connection = getPostgreSQLConnection();
   const ping = await connection.ping();
   await connection.close();
 

--- a/tests/units/connectors/postgres/connection.test.ts
+++ b/tests/units/connectors/postgres/connection.test.ts
@@ -1,0 +1,10 @@
+import { getPostgreSQLPoolConnection } from "../../../connection.ts";
+import { assertEquals } from "../../../deps.ts";
+
+Deno.test("PostgreSQL: Connection", async function () {
+  const connection = getPostgreSQLPoolConnection();
+  const ping = await connection.ping();
+  await connection.close();
+
+  assertEquals(ping, true);
+});


### PR DESCRIPTION
Added stable support for Pooling in Postgres. 
A few changes have been made in order to achieve a consistent code. 

- `deno.json` and `import_map.json` have been added for add support to old node libraries;

- in the `Connector` interface, for code design issues I had to put `_client `and `_connected` as optional due to inchoerence with the pool existence;

- `PostgresPoolOptions`  has been added and relies on the original options of Postgres Pool;

- `PostgresConnector` has been modified with substantial edits in the various exposed methods;

- `Database` has been modified with the underlying connector implementation of `_pool`.