### PR TITLE
fix: module not found "https://deno.land/std/hash/mod.ts".

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -10,8 +10,8 @@ export {
   Client as MySQLClient,
   configLogger as configMySQLLogger,
   Connection as MySQLConnection,
-} from "https://deno.land/x/mysql@v2.10.1/mod.ts";
-export type { LoggerConfig } from "https://deno.land/x/mysql@v2.10.1/mod.ts";
+} from "https://deno.land/x/mysql@v2.10.3/mod.ts";
+export type { LoggerConfig } from "https://deno.land/x/mysql@v2.10.3/mod.ts";
 
 export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.14.2/mod.ts";
 


### PR DESCRIPTION
This fixes a dependency issue which prevented the installation of denodb.

Version `2.10.1` of the [mysql driver](https://github.com/denodrivers/mysql) used [`god_crypto`](https://github.com/invisal/god_crypto) as a dependency which relied on the [deprecated and now removed](https://github.com/denoland/deno_std/commit/c1e1240c0343f019a6727e741e024fb34c450bbf) `deno std/hash`. Version [2.10.3](https://github.com/denodrivers/mysql/releases/tag/v2.10.3) of the mysql driver [ditches this dependency in favour of SubteCrypto](https://github.com/denodrivers/mysql/pull/132).

This should not break anything, as it is only a patch level update. 
Tested with MariaDB using the MySQLConnector.